### PR TITLE
docs: 補齊 README 功能清單，CI 改配合 branch+PR 流程

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: Build
 
 on:
   push:
-    branches-ignore:
-      - 'release-please--**'
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -3,14 +3,14 @@ name: Deny
 on:
   push:
     branches:
-      - '*'
+      - main
     paths:
       - '**/Cargo.lock'
       - '**/Cargo.toml'
       - '**/deny.toml'
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - '**/Cargo.lock'
       - '**/Cargo.toml'

--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ Serie（[`/zéːriə/`](docs/src/faq/index.md)）是一個 TUI 應用程式，�
 
 以下功能為此 fork 新增，原版 serie 不包含：
 
+- **GitHub Issue/PR 瀏覽器** — 按 `g` 開啟，瀏覽與篩選 issue／PR、切換 checkbox、三階段確認 merge PR、開關 issue/PR 狀態、複製連結或在瀏覽器開啟
 - **Tag 管理** — 按 `t` 建立 tag，`Ctrl-t` 刪除 tag，支援推送到 remote
 - **Remote refs 切換** — 按 `o` 顯示/隱藏 remote-only 的 commit，使用 BFS filtered graph 重新計算佈局
 - **Ref 刪除** — 在 refs 列表中刪除 branch（local/remote）或 tag
 - **篩選 (Filter)** — 按 `'` 篩選 commit 列表（`f` 是 fetch）
+- **緊湊模式 (Compact)** — `-c` 讓 commit 文字貼齊該列圖形實際延伸的位置，依終端機寬度自動判斷要不要開
+- **互動式目錄瀏覽器** — `-p` 用類似 ranger 的介面選擇要開啟的 git 儲存庫路徑
 - **狀態列快捷鍵提示** — 狀態列顯示當前視圖可用的快捷鍵
 - **等待覆蓋層** — 長時間 git 操作（push/delete remote）時顯示等待提示
 


### PR DESCRIPTION
## Summary
- README「Fork 新增功能」清單補上 GitHub issue/PR 瀏覽器、緊湊模式、互動式目錄瀏覽器（原本只在選項表格出現）
- `build.yml`／`deny.yml` 的 `pull_request` 目標分支修正 `master` → `main`（這個 fork 預設分支是 `main`，原本這條規則從未生效）
- `push` 觸發範圍收斂成只有 `main`：往後開發走 `branch (yymmdd) + PR` 流程，分支驗證交給 `pull_request` 事件，`push` 只在 merge 進 main 後驗證最終狀態，不會重複測兩次幾乎相同的內容——這個 PR 本身就是新流程的第一次實際套用

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test`
- [ ] 這個 PR 的 CI（`pull_request` 觸發）跑綠