### PR TITLE
fix: release CI 的 Cargo.lock 同步改直接改欄位，不呼叫 cargo metadata

### DIFF
--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CARGO_TOML = REPO_ROOT / "Cargo.toml"
+CARGO_LOCK = REPO_ROOT / "Cargo.lock"
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 
 # commit type -> (CHANGELOG section 標題, bump 等級)。等級為 None 代表該
@@ -148,23 +149,58 @@ def bump_version(current: str, level: str) -> str:
     return f"{major}.{minor}.{patch + 1}"
 
 
-def find_package_version(lines: list[str]) -> tuple[int, str]:
-    """回傳 [package] 區塊下 version 欄位所在的 (行號, 版本字串)。
+def find_package_info(lines: list[str]) -> tuple[int, str, str]:
+    """回傳 Cargo.toml [package] 區塊的 (version 所在行號, name, version)。
 
-    讀（算 old_version）與寫（改版號）共用同一份掃描邏輯與同一個行號，
-    避免兩份各自維護的 [package] 掃描器互相漂移。
+    name 動態讀出來，不硬編 package 名稱——同一份 name 接著用來在
+    Cargo.lock 裡定位對應的 [[package]] 區塊。
     """
     in_package = False
+    name: str | None = None
+    version_idx: int | None = None
+    version: str | None = None
     for i, line in enumerate(lines):
         stripped = line.strip()
         if stripped.startswith("["):
             in_package = stripped == "[package]"
             continue
-        if in_package:
+        if not in_package:
+            continue
+        m = re.match(r'name\s*=\s*"([^"]+)"', stripped)
+        if m:
+            name = m.group(1)
+            continue
+        m = re.match(r'version\s*=\s*"([^"]+)"', stripped)
+        if m:
+            version_idx, version = i, m.group(1)
+    if name is None or version_idx is None:
+        raise SystemExit("找不到 [package] 區塊下的 name/version 欄位")
+    return version_idx, name, version
+
+
+def find_lock_version(lines: list[str], package_name: str) -> tuple[int, str]:
+    """回傳 Cargo.lock 裡 package_name 的 [[package]] 區塊中 version 欄位的
+    (行號, 版本字串)。
+
+    直接文字取代，不呼叫 `cargo`——CI runner 是全新環境，沒有本機 registry
+    cache，`cargo metadata --offline` 連 index 都讀不到會直接失敗；而這裡
+    要做的只是把本 package 自己的 version 欄位同步成新版號，純本地文字操作，
+    不需要真的做依賴解析。
+    """
+    in_block = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "[[package]]":
+            in_block = False
+            continue
+        if stripped == f'name = "{package_name}"':
+            in_block = True
+            continue
+        if in_block:
             m = re.match(r'version\s*=\s*"([^"]+)"', stripped)
             if m:
                 return i, m.group(1)
-    raise SystemExit("找不到 [package] 區塊下的 version 欄位")
+    raise SystemExit(f"Cargo.lock 找不到 {package_name} 的 version 欄位")
 
 
 def entry_link(repo: str, commit: Commit, pr_map: dict[str, int]) -> str:
@@ -244,7 +280,7 @@ def main() -> int:
         return 0
 
     cargo_lines = CARGO_TOML.read_text().splitlines(keepends=True)
-    version_idx, old_version = find_package_version(cargo_lines)
+    version_idx, package_name, old_version = find_package_info(cargo_lines)
     new_version = bump_version(old_version, bump)
     pr_map = build_pr_map(args.base)
     today = date.today().isoformat()
@@ -262,6 +298,11 @@ def main() -> int:
         r'"[^"]+"', f'"{new_version}"', cargo_lines[version_idx], count=1
     )
     CARGO_TOML.write_text("".join(cargo_lines))
+
+    lock_lines = CARGO_LOCK.read_text().splitlines(keepends=True)
+    lock_idx, _ = find_lock_version(lock_lines, package_name)
+    lock_lines[lock_idx] = re.sub(r'"[^"]+"', f'"{new_version}"', lock_lines[lock_idx], count=1)
+    CARGO_LOCK.write_text("".join(lock_lines))
 
     header = "# Changelog\n\n"
     text = CHANGELOG.read_text()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
         env:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
-          cargo metadata --offline --format-version 1 > /dev/null  # 讓 Cargo.lock 版號跟上
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml Cargo.lock CHANGELOG.md


### PR DESCRIPTION
## 變更摘要

- 修正 #37 merge 後 release.yml 第一次實跑就炸掉的問題：`prepare` job 的
  `cargo metadata --offline` 在全新 CI runner（沒有本機 registry cache）上
  以 exit code 101 失敗，`--offline` 連 `ansi-to-tui` 的 index 都讀不到
- main 上沒留下半殘狀態：`git push --atomic` 生效，沒有 release commit 也
  沒有孤兒 tag，只是版號沒真的發出去
- `prepare_release.py` 新增 `find_lock_version()`，跟改 `Cargo.toml` 版號
  同一套文字取代邏輯直接改 `Cargo.lock` 對應 `[[package]]` 區塊的 version
  欄位——`serie` 是 workspace root，`Cargo.lock` 裡只有它自己這一處引用，
  沒有其他 package 依賴它，不需要 cargo 做依賴解析
- package name 動態從 `Cargo.toml` 讀出來，不硬編字串
- `release.yml` 拿掉 `cargo metadata` 那個 step

## 驗證

用實際的 `origin/main`（含 #37 merge commit）建暫時 worktree，直接跑
`prepare_release.py --from v2.0.0`，確認：
- 版本正確算出 `2.1.0`（`feat:` → minor）
- `Cargo.toml` 與 `Cargo.lock` 的 version 欄位都同步更新，`Cargo.lock` diff
  只有那一行，沒有動到其他 package
- CHANGELOG 條目正確連到 `#37`

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] 未改動任何 `.rs` 檔，沿用本次 session 稍早已通過的 `cargo test --verbose`（347+1+20+5 全過）