### PR TITLE
chore: package/crate 改名 serie → ysgit，metadata 改指向這個 fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,39 +2064,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serie"
-version = "2.2.0"
-dependencies = [
- "ansi-to-tui",
- "arboard",
- "base64 0.22.1",
- "chrono",
- "clap",
- "console",
- "dircpy",
- "emojis",
- "fuzzy-matcher",
- "garde",
- "laurier",
- "notify",
- "notify-debouncer-mini",
- "ratatui",
- "rstest",
- "rustc-hash",
- "semver",
- "serde",
- "serde_json",
- "signal-hook",
- "smart-default",
- "tempfile",
- "toml",
- "tui-input",
- "tui-tree-widget",
- "umbra",
- "unicode-width",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3150,6 +3117,39 @@ name = "x11rb-protocol"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+
+[[package]]
+name = "ysgit"
+version = "2.2.0"
+dependencies = [
+ "ansi-to-tui",
+ "arboard",
+ "base64 0.22.1",
+ "chrono",
+ "clap",
+ "console",
+ "dircpy",
+ "emojis",
+ "fuzzy-matcher",
+ "garde",
+ "laurier",
+ "notify",
+ "notify-debouncer-mini",
+ "ratatui",
+ "rstest",
+ "rustc-hash",
+ "semver",
+ "serde",
+ "serde_json",
+ "signal-hook",
+ "smart-default",
+ "tempfile",
+ "toml",
+ "tui-input",
+ "tui-tree-widget",
+ "umbra",
+ "unicode-width",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "serie"
+name = "ysgit"
 version = "2.2.0"
 description = "A rich git commit graph in your terminal, like magic"
-authors = ["Kyosuke Fujimoto <kyoro.f@gmail.com>"]
-homepage = "https://github.com/lusingander/serie"
-repository = "https://github.com/lusingander/serie"
+authors = ["YSEthan"]
+homepage = "https://github.com/YSzEthan/serie-ys"
+repository = "https://github.com/YSzEthan/serie-ys"
 readme = "README.md"
 license = "MIT"
 keywords = ["git", "cli", "tui", "terminal"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,3 @@
-fn main() -> serie::Result<()> {
-    serie::run()
+fn main() -> ysgit::Result<()> {
+    ysgit::run()
 }

--- a/tests/emoji.rs
+++ b/tests/emoji.rs
@@ -7,8 +7,8 @@
 use std::path::Path;
 use std::process::{Command, Output};
 
-use serie::git::{Ref, Repository, SortCommit};
 use tempfile::TempDir;
+use ysgit::git::{Ref, Repository, SortCommit};
 
 fn git(path: &Path, args: &[&str]) -> Output {
     let out = Command::new("git")

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, process::Command};
 
 use chrono::{DateTime, Days, NaiveDate, TimeZone, Utc};
-use serie::{color, config, git, graph};
+use ysgit::{color, config, git, graph};
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 


### PR DESCRIPTION
## 變更摘要

- `[[bin]]` 早就叫 `ysgit`，`[package] name` 卻還是 `serie`，導致 `Cargo.toml` 的 `authors`/`homepage`/`repository` 全部指向上游 `lusingander/serie`，而不是這個 fork 自己的身分
- `[package] name` 改成 `ysgit`，連帶把函式庫 crate 路徑（`main.rs`、`tests/emoji.rs`、`tests/graph.rs` 三處 `use serie::...`）一併換成 `ysgit::`，避免 package 名跟程式碼裡實際的 crate 路徑不一致
- `authors` 只留 GitHub 帳號名稱，不放 email——GitHub 個人資料的 email 本來就設成不公開，不該透過會隨 crate metadata 曝光的欄位洩漏
- `homepage`/`repository` 改指向 `YSzEthan/serie-ys`
- `Cargo.lock` 交給 `cargo check` 自動同步，只是套件名稱換了排序位置跟名字，依賴清單本身沒變
- README 開頭「這是 lusingander/serie 的 fork」那行是致謝上游，維持不動

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --verbose` 通過（358 個 lib test 全過）