### PR TITLE
fix: GitHub Release 補上 CHANGELOG 區塊當說明文字

### DIFF
--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -243,6 +243,22 @@ def build_changelog_block(
     return "\n".join(lines)
 
 
+def extract_changelog_section(version: str) -> str:
+    """回傳 CHANGELOG.md 裡 `## [version]` 那個區塊的內容（含標題，到下一個
+    `## [` 前為止）。供 release.yml 的 upload job 取出當次版本的區塊當
+    GitHub Release 的說明文字，不用另外傳遞任何中間產物——`prepare` job
+    已經 commit 過的 CHANGELOG.md 就是唯一真相。
+    """
+    text = CHANGELOG.read_text()
+    marker = f"## [{version}]"
+    start = text.find(marker)
+    if start == -1:
+        raise SystemExit(f"CHANGELOG.md 找不到 {marker} 這個區塊")
+    next_marker = text.find("\n## [", start + len(marker))
+    end = next_marker if next_marker != -1 else len(text)
+    return text[start:end].rstrip("\n")
+
+
 def detect_repo() -> str:
     env = os.environ.get("GITHUB_REPOSITORY")
     if env:
@@ -264,12 +280,25 @@ def emit_github_output(name: str, value: str) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--from", dest="base", required=True, help="上一個版本的 tag，例如 v1.9.0")
+    parser.add_argument("--from", dest="base", help="上一個版本的 tag，例如 v1.9.0")
     parser.add_argument(
         "--dry-run", action="store_true", help="只印出計算結果，不寫入 Cargo.toml / CHANGELOG.md"
     )
     parser.add_argument("--repo", help="owner/repo，預設從 GITHUB_REPOSITORY 或 git remote 解析")
+    parser.add_argument(
+        "--print-section",
+        metavar="VERSION",
+        help="印出 CHANGELOG.md 裡指定版本（不含前導 v）的區塊，印完就結束，"
+        "不做本檔案其他任何事，也不需要 --from",
+    )
     args = parser.parse_args()
+
+    if args.print_section:
+        print(extract_changelog_section(args.print_section))
+        return 0
+
+    if not args.base:
+        parser.error("--from 是必填（除非搭配 --print-section）")
 
     repo = args.repo or detect_repo()
     commits = load_commits(args.base)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,14 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+      - name: Extract release notes from CHANGELOG.md
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          python3 .github/scripts/prepare_release.py --print-section "${TAG#v}" > release-notes.md
       - uses: actions/download-artifact@v4
         with:
           path: releases
@@ -117,5 +125,6 @@ jobs:
       - uses: softprops/action-gh-release@v2.0.4
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
+          body_path: release-notes.md
           files: releases/*
           make_latest: true


### PR DESCRIPTION
## 變更摘要

- `upload` job 呼叫 `softprops/action-gh-release` 完全沒帶 `body`/`body_path`，release 頁面（例如 `v2.2.0`）說明文字整個是空的
- `prepare_release.py` 新增 `--print-section VERSION`：從已 commit 的 `CHANGELOG.md` 抓出該版本的區塊（到下一個 `## [` 前為止）直接印出
- `upload` job 加一個 checkout（釘住 `prepare` job 建的 tag）+ 一個抽取步驟，產出的 `release-notes.md` 傳給 `body_path`
- 不用在 job 之間傳遞任何中間產物：`prepare` job 已經 commit 過的 `CHANGELOG.md` 本身就是唯一真相，`upload` job 直接照 tag 重新讀一次就好

## 驗證

- 用真實的 `CHANGELOG.md` 跑過 `--print-section 2.2.0`、`--print-section 1.8.0`（中段版本，驗證邊界抓對）、`--print-section 9.9.9`（不存在版本，確認會報錯而不是印空字串），輸出都正確

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --verbose` 通過（358 個 lib test，本次未改動任何 `.rs` 檔）