### PR TITLE
fix: GitHub view 提示列格式、Vercel HTML 留言、SSH/mosh 開連結三處修正

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -37,25 +37,6 @@ use status_line::StatusLineState;
 
 mod status_line;
 
-const SSH_OPEN_PREFIX: &str = "SSH: ⌘/⌥/⇧+Click ";
-
-/// OSC 8 超連結的簡短標籤。GitHub issue/PR 網址會縮成
-/// `[#N]`；其他一律 fallback 成 `[open]`。用 host 限定在 `github.com`，
-/// 避免像 `https://example.com/blog/issues/2024` 這種網址被誤判。
-fn short_link_label(url: &str) -> String {
-    let on_github = url.starts_with("https://github.com/") || url.starts_with("http://github.com/");
-    let is_issue_or_pr = url.contains("/issues/") || url.contains("/pull/");
-    let tail = url.trim_end_matches('/').rsplit('/').next();
-    if let (true, true, Some(n)) = (
-        on_github,
-        is_issue_or_pr,
-        tail.and_then(|s| s.parse::<u64>().ok()),
-    ) {
-        return format!("[#{n}]");
-    }
-    "[open]".to_string()
-}
-
 #[derive(Clone, Copy)]
 pub enum InitialSelection {
     Latest,
@@ -1534,12 +1515,19 @@ impl App<'_> {
             Ok(crate::external::OpenUrlOutcome::Spawned) => {
                 self.ec.send(AppEvent::NotifyInfo(format!("Opening {url}")));
             }
-            Ok(crate::external::OpenUrlOutcome::Hyperlinked(url)) => {
-                self.status_line_state.set_notification_hyperlink(
-                    SSH_OPEN_PREFIX,
-                    short_link_label(&url),
-                    url,
-                );
+            // 沒有本機瀏覽器可 spawn（SSH／mosh）。OSC 8 在這條路徑上沒有能
+            // 動的版本——mosh 的終端模擬器直接吃掉整個 OSC 8 序列（沒有
+            // hyperlink 欄位可存），tmux 的 DCS passthrough 則會讓 label
+            // 印到錯的座標、後續畫面留下殘骸（見 git log 這次變更的說明）。
+            // 改印純文字 URL：ghostty／iTerm2／WezTerm／Kitty 本來就有 URL
+            // 偵測，⌘+Click 一樣能開，而且穿得過 mosh 和 tmux。
+            //
+            // 同步賦值，不透過 `ec` 送事件——理由同
+            // `StatusLineState::open_related_picker` 文件註解：這一輪迴圈
+            // 才不會先閃一下 hint 列才出現通知。
+            Ok(crate::external::OpenUrlOutcome::NotSpawned) => {
+                self.status_line_state
+                    .set_notification_info(format!("SSH: {url}"));
             }
             Err(msg) => {
                 self.ec.send(AppEvent::NotifyError(msg));
@@ -2000,17 +1988,6 @@ mod tests {
             global_app_event(UserEvent::HelpToggle, true, false),
             Some(AppEvent::OpenHelp)
         ));
-    }
-
-    #[rstest]
-    #[case("https://github.com/o/r/issues/123", "[#123]")]
-    #[case("https://github.com/o/r/pull/456", "[#456]")]
-    #[case("https://github.com/o/r/issues/123/", "[#123]")]
-    #[case("https://github.com/o/r/commit/abcd1234", "[open]")]
-    #[case("https://example.com/", "[open]")]
-    #[case("https://github.com/o/r/issues/not-a-number", "[open]")]
-    fn short_link_label_extracts_issue_pr_number(#[case] url: &str, #[case] expected: &str) {
-        assert_eq!(short_link_label(url), expected);
     }
 
     // ---- GitHubLoad -----------------------------------------------------

--- a/src/app/status_line.rs
+++ b/src/app/status_line.rs
@@ -156,14 +156,6 @@ enum StatusLine {
     NotificationSuccess(String),
     NotificationWarn(String),
     NotificationError(String),
-    /// 尾端是 OSC 8 超連結的通知。渲染時必須繞過 `Line::raw`——
-    /// 它會把跳脫序列逐 byte 拆到不同 cell——改成用
-    /// `set_symbol` + 後續 cell 的 `set_skip` 把整包 payload 塞進單一 cell。
-    NotificationHyperlink {
-        prefix: &'static str,
-        label: String,
-        url: String,
-    },
 }
 
 #[derive(Debug)]
@@ -292,15 +284,6 @@ impl StatusLineState {
         self.line = StatusLine::NotificationError(msg);
     }
 
-    pub(super) fn set_notification_hyperlink(
-        &mut self,
-        prefix: &'static str,
-        label: String,
-        url: String,
-    ) {
-        self.line = StatusLine::NotificationHyperlink { prefix, label, url };
-    }
-
     /// 回傳 true 表示這是 9 個攔截變體之一（7 個 handler：`ToggleStatePrompt`、
     /// `TogglePrDraftPrompt`、`UpdatePrompt` 三個共用 `handle_yes_no_prompt_key`，
     /// 其餘各自一個 handler）、鍵已被吃掉。
@@ -345,8 +328,7 @@ impl StatusLineState {
             | StatusLine::NotificationInfo(_)
             | StatusLine::NotificationSuccess(_)
             | StatusLine::NotificationWarn(_)
-            | StatusLine::NotificationError(_)
-            | StatusLine::NotificationHyperlink { .. } => false,
+            | StatusLine::NotificationError(_) => false,
         }
     }
 
@@ -368,8 +350,7 @@ impl StatusLineState {
             | StatusLine::UpdatePrompt { .. } => false,
             StatusLine::NotificationInfo(_)
             | StatusLine::NotificationSuccess(_)
-            | StatusLine::NotificationWarn(_)
-            | StatusLine::NotificationHyperlink { .. } => {
+            | StatusLine::NotificationWarn(_) => {
                 self.line = StatusLine::None;
                 false
             }
@@ -403,8 +384,7 @@ impl StatusLineState {
             | StatusLine::NotificationInfo(_)
             | StatusLine::NotificationSuccess(_)
             | StatusLine::NotificationWarn(_)
-            | StatusLine::NotificationError(_)
-            | StatusLine::NotificationHyperlink { .. } => false,
+            | StatusLine::NotificationError(_) => false,
         }
     }
 
@@ -647,10 +627,6 @@ impl StatusLineState {
 
     pub(super) fn render(&self, f: &mut Frame, area: Rect, view: &View, numeric_prefix: &str) {
         let text: Line = match &self.line {
-            StatusLine::NotificationHyperlink { prefix, label, url } => {
-                self.render_hyperlink_notification(f, area, prefix, label, url);
-                return;
-            }
             StatusLine::None => {
                 if numeric_prefix.is_empty() {
                     build_hotkey_hints(view, &self.ctx)
@@ -761,38 +737,6 @@ impl StatusLineState {
                     f.buffer_mut().set_string(x, y, cursor, style);
                 }
             }
-        }
-    }
-
-    fn render_hyperlink_notification(
-        &self,
-        f: &mut Frame,
-        area: Rect,
-        prefix: &str,
-        label: &str,
-        url: &str,
-    ) {
-        let block = Block::default()
-            .borders(Borders::TOP)
-            .style(Style::default().fg(self.ctx.color_theme.divider_fg))
-            .padding(Padding::horizontal(1));
-        let inner = block.inner(area);
-        f.render_widget(block, area);
-
-        let buf = f.buffer_mut();
-        let style = Style::default().fg(self.ctx.color_theme.status_info_fg);
-        buf.set_string(inner.left(), inner.top(), prefix, style);
-        let prefix_w = console::measure_text_width(prefix) as u16;
-        let x0 = inner.left().saturating_add(prefix_w);
-        if x0 >= inner.right() {
-            return;
-        }
-        let payload = crate::external::format_osc8_hyperlink(url, label);
-        let label_width = console::measure_text_width(label) as u16;
-        buf[(x0, inner.top())].set_symbol(&payload).set_style(style);
-        let remaining = inner.right().saturating_sub(x0);
-        for i in 1..label_width.min(remaining) {
-            buf[(x0 + i, inner.top())].set_skip(true);
         }
     }
 
@@ -1186,7 +1130,7 @@ mod tests {
         assert!(rx.try_recv().is_err());
     }
 
-    /// `StatusLine` 全部 16 個變體各自對 `handle_intercepting_key`／
+    /// `StatusLine` 全部 15 個變體各自對 `handle_intercepting_key`／
     /// `is_input_mode_variant` 的回傳值，把「兩者故意不同步」這件事從一句
     /// 註解變成有東西擋著的不變式（做法比照這個 session 的 `2fa4064` 先
     /// 例）。4 個 prompt 變體在 handle_intercepting_key 永遠攔截，但
@@ -1303,26 +1247,16 @@ mod tests {
                 false,
                 false,
             ),
-            (
-                "NotificationHyperlink",
-                StatusLine::NotificationHyperlink {
-                    prefix: "",
-                    label: String::new(),
-                    url: String::new(),
-                },
-                false,
-                false,
-            ),
         ];
 
         assert_eq!(
             cases.len(),
-            16,
-            "StatusLine 有 16 個變體，表格漏列或多列了，先檢查表格本身"
+            15,
+            "StatusLine 有 15 個變體，表格漏列或多列了，先檢查表格本身"
         );
 
         for (label, line, want_intercept, want_input_mode) in cases {
-            // handle_intercepting_key 在 8 個攔截變體上會呼叫對應 handler、
+            // handle_intercepting_key 在 9 個攔截變體上會呼叫對應 handler、
             // 可能改變 self.line 或送事件——這裡只關心它的回傳值，用一個
             // 全新的 state 避免副作用互相汙染。
             let mut for_intercept = make(line.clone());

--- a/src/external.rs
+++ b/src/external.rs
@@ -177,12 +177,12 @@ fn copy_to_clipboard_auto(value: String) -> Result<(), String> {
     })
 }
 
-/// `open_url` 的結果。`Hyperlinked` 表示我們無法（或不該）在本機開瀏覽器 ——
-/// 呼叫端應改為把這個 URL 呈現成 OSC 8 可點擊按鈕，交給使用者本機終端機的
-/// 瀏覽器處理。
+/// `open_url` 的結果。`NotSpawned`：沒有本機瀏覽器可開（SSH／mosh），
+/// 呼叫端負責把 URL 顯示出來、讓終端自己偵測——理由見它的呼叫端
+/// `App::open_url`。
 pub enum OpenUrlOutcome {
     Spawned,
-    Hyperlinked(String),
+    NotSpawned,
 }
 
 pub fn open_url(url: &str) -> Result<OpenUrlOutcome, String> {
@@ -191,7 +191,7 @@ pub fn open_url(url: &str) -> Result<OpenUrlOutcome, String> {
     }
 
     if is_ssh_session() {
-        return Ok(OpenUrlOutcome::Hyperlinked(url.to_string()));
+        return Ok(OpenUrlOutcome::NotSpawned);
     }
 
     #[cfg(target_os = "macos")]
@@ -210,15 +210,15 @@ pub fn open_url(url: &str) -> Result<OpenUrlOutcome, String> {
 }
 
 /// 把 URL 加標籤格式化成 OSC 8 超連結跳脫序列。支援 OSC 8 的終端機（ghostty、
-/// iTerm2、Kitty、WezTerm）會把標籤渲染成可點擊連結。tmux 會另外包一層
-/// DCS passthrough。
+/// iTerm2、Kitty、WezTerm）會把標籤渲染成可點擊連結。
+///
+/// **呼叫端負責在 tmux 下跳過**，不要指望這裡處理：tmux 的 DCS passthrough
+/// 會把 inner sequence 直接轉發給外層終端、不保留游標定位，疊在 cell 上的
+/// label 會被印到任意座標。這在「疊加在同寬度純文字上」的場景（GitHub
+/// 列表／預覽的 `#N`）能被 `is_tmux()` early-return 安全跳過——跳過後看到
+/// 的仍是正確的純文字；換成別的場景前，先確認一樣有純文字可以退回。
 pub fn format_osc8_hyperlink(url: &str, label: &str) -> String {
-    let raw = format!("\x1b]8;;{url}\x1b\\{label}\x1b]8;;\x1b\\");
-    if is_tmux() {
-        wrap_for_tmux(&raw)
-    } else {
-        raw
-    }
+    format!("\x1b]8;;{url}\x1b\\{label}\x1b]8;;\x1b\\")
 }
 
 pub struct ExternalCommandParameters<'a> {
@@ -351,11 +351,7 @@ mod tests {
     }
 
     #[test]
-    fn format_osc8_hyperlink_plain_no_tmux() {
-        // 跑 test 通常不在 tmux 內；若在 tmux 下請跳過此檢查。
-        if is_tmux() {
-            return;
-        }
+    fn format_osc8_hyperlink_wraps_url_and_label() {
         assert_eq!(
             format_osc8_hyperlink("https://x.com", "[#1]"),
             "\x1b]8;;https://x.com\x1b\\[#1]\x1b]8;;\x1b\\"

--- a/src/view/github/mod.rs
+++ b/src/view/github/mod.rs
@@ -566,7 +566,9 @@ impl<'a> GitHubView<'a> {
                     h(&[UserEvent::Confirm], "preview"),
                     h(&[UserEvent::Refresh], "refresh"),
                     h(&[UserEvent::Filter], "filter"),
-                    h(&[UserEvent::ShortCopy], "copy url / C open / v #num"),
+                    h(&[UserEvent::ShortCopy], "copy url"),
+                    h(&[UserEvent::FullCopy], "open"),
+                    h(&[UserEvent::TagCopy], "#num"),
                 ]);
                 hints.extend(self.commit_log_hint());
                 if self.selected_has_related() {
@@ -576,6 +578,104 @@ impl<'a> GitHubView<'a> {
                 hints
             }
         }
+    }
+
+    /// 這個 view 有可能顯示的每一條狀態列提示，給
+    /// `help::status_hints_are_bound_and_documented` 拿去跟說明頁比對。
+    ///
+    /// 樣本資料與掃描都放在這裡而不是 help 裡：`focus`／`active_tab` 這些欄位
+    /// 對別的模組是私有的，而「哪些狀態組合會長出不同提示」也只有這個模組知道。
+    #[cfg(test)]
+    pub(crate) fn every_status_hint() -> Vec<HintSpec> {
+        use crate::github::{GhAuthor, GhRelatedIssue};
+
+        let author = || GhAuthor {
+            login: "alice".to_string(),
+        };
+        let related = || {
+            vec![GhRelatedIssue {
+                number: 9,
+                title: "related".to_string(),
+                state: "OPEN".to_string(),
+                url: String::new(),
+            }]
+        };
+        let issue = |number, state: &str, sub_issues: Vec<GhRelatedIssue>| GhIssue {
+            number,
+            title: "t".to_string(),
+            state: state.to_string(),
+            labels: Vec::new(),
+            author: author(),
+            created_at: String::new(),
+            body: String::new(),
+            url: String::new(),
+            closed_at: None,
+            updated_at: String::new(),
+            parent: None,
+            sub_issues,
+        };
+        let pr = |number, state: &str, is_draft, linked_issues| GhPullRequest {
+            number,
+            title: "t".to_string(),
+            state: state.to_string(),
+            labels: Vec::new(),
+            author: author(),
+            head_ref_name: "topic".to_string(),
+            base_ref_name: "main".to_string(),
+            is_draft,
+            body: String::new(),
+            url: String::new(),
+            closed_at: None,
+            updated_at: String::new(),
+            linked_issues,
+        };
+
+        let data = GitHubData {
+            issues: vec![issue(1, "OPEN", related()), issue(2, "CLOSED", Vec::new())],
+            pull_requests: vec![
+                pr(3, "OPEN", false, related()),
+                pr(4, "OPEN", true, Vec::new()),
+                pr(5, "MERGED", false, Vec::new()),
+            ],
+            ..Default::default()
+        };
+        let (tx, _rx) = Sender::channel_for_test();
+        let mut view = GitHubView::new(View::Default, data, tx);
+
+        let mut all = Vec::new();
+        for focus in [
+            GitHubFocus::List,
+            GitHubFocus::Preview,
+            GitHubFocus::Prompt,
+            GitHubFocus::CheckboxEdit,
+        ] {
+            for tab in [GitHubTab::Issues, GitHubTab::PullRequests] {
+                for expand in [false, true] {
+                    view.focus = focus;
+                    view.active_tab = tab;
+                    view.expand_commits = expand;
+                    for i in 0..view.current_list_len() {
+                        view.selected_index = i;
+                        all.extend(view.status_hints());
+                    }
+                }
+            }
+        }
+
+        // 空清單的三條分支走的是另一組提示，清單有東西時掃不到。
+        view.issues.clear();
+        view.pull_requests.clear();
+        view.focus = GitHubFocus::List;
+        for state in [
+            LoadState::Idle,
+            LoadState::Loading,
+            LoadState::Error(String::new()),
+        ] {
+            view.load_state = state;
+            all.extend(view.status_hints());
+        }
+
+        all
     }
 
     /// 收合／展開不會重置 `preview_offset`——跟另外約 20 個在導覽時會重置

--- a/src/view/github/render.rs
+++ b/src/view/github/render.rs
@@ -188,8 +188,13 @@ impl<'a> GitHubView<'a> {
 
         // 對每個可視列的 `#N` 疊加 OSC 8。cell 版面配置定義在
         // `LIST_LINK_COL_OFFSET`——要跟 indicator + padding 保持同步。
-        // tmux 的 DCS passthrough 會遺失游標定位，導致 host 終端機把 label
-        // 畫在任意欄位——在 tmux 裡跳過疊加。
+        //
+        // OSC 8 只用在「畫面上那段文字本身不可能是網址」的地方——`#123`
+        // 沒有終端能猜出它是連結，只能靠 OSC 8。這裡能安全疊加是因為底稿
+        // 已經畫了同寬度的純文字 `#N`：tmux 的 DCS passthrough 會遺失游標
+        // 定位，導致 host 終端機把 label 畫到任意欄位，但在 tmux 裡跳過疊加
+        // 時看到的仍是正確的純文字，不會露出殘骸（跟狀態列那則通知改印純
+        // URL 是同一個判準，見 `app.rs::open_url`）。
         if crate::external::is_tmux() {
             return;
         }
@@ -379,8 +384,9 @@ impl<'a> GitHubView<'a> {
 
         // 用 OSC 8 超連結疊加 `#N` cell。必須在 Paragraph render 之後執行，
         // 才能覆蓋掉先前畫上去的純文字 `#N` 字元。
-        // tmux 的 DCS passthrough 會遺失游標定位，導致 host 終端機把 label
-        // 畫在任意欄位——在 tmux 裡跳過疊加。
+        //
+        // 跳過 tmux 的判準同上面 `render_list` 那份註解：能安全 early-return
+        // 是因為底下已經有同寬度的純文字 `#N` 可以退回。
         if crate::external::is_tmux() {
             return;
         }

--- a/src/view/help.rs
+++ b/src/view/help.rs
@@ -590,6 +590,10 @@ mod tests {
             HelpBlock::UserCommand,
             crate::view::user_command::status_hints(),
         );
+        check(
+            HelpBlock::GitHub,
+            crate::view::github::GitHubView::every_status_hint(),
+        );
 
         assert!(problems.is_empty(), "\n{}", problems.join("\n"));
     }

--- a/src/view/markdown.rs
+++ b/src/view/markdown.rs
@@ -3,14 +3,16 @@
 //! 以行為單位處理，不依賴外部 crate。支援：標題（1-3 級）、
 //! 無序／有序列表、引言區塊、水平線、fenced code、依可用寬度排版的
 //! GFM 表格、`**bold**`、`` `code` ``、`[text](url)` 以及
-//! HTML 實體。連結參考定義、HTML 註解與原始 HTML 一律捨棄——
-//! bot 留言（Vercel、CI）充斥這些東西，而它們在終端機裡什麼都顯示不出來。
-//! `*italic*` 則沒有處理。
+//! HTML 實體。連結參考定義、HTML 註解與 HTML 標籤一律捨棄（標籤是行內
+//! 剝除，剝完什麼都不剩的行整行丟掉）——bot 留言（Vercel、CI）充斥這些
+//! 東西，而它們在終端機裡什麼都顯示不出來。`*italic*` 則沒有處理。
 
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
+
+use crate::widget::{split_at_width, str_width};
 
 const RULE_WIDTH: usize = 40;
 
@@ -75,12 +77,6 @@ pub fn render(body: &str, width: usize) -> Vec<Line<'static>> {
 
         // 渲染後的 markdown 看不到；Vercel 會產生一大段 base64。
         if is_link_reference_definition(line) {
-            i += 1;
-            continue;
-        }
-
-        // 區塊層級的原始 HTML（`<a href=…>`、`<picture>`、`</div>`）。
-        if is_html_block(line) {
             i += 1;
             continue;
         }
@@ -173,8 +169,14 @@ pub fn render(body: &str, width: usize) -> Vec<Line<'static>> {
             continue;
         }
 
-        // 一般文字行，做行內掃描
+        // 一般文字行，做行內掃描。掃完一無所剩、原始行卻不是空白，代表整行
+        // 都是被剝掉的標記（bot 留言常見的整行 `<a><picture>…`）或一張圖片——
+        // 連空行都不要留，否則 Vercel 那種留言會被撐出一堆空隙。
         let spans = scan_inline(line);
+        if spans.is_empty() && !line.trim().is_empty() {
+            i += 1;
+            continue;
+        }
         out.push(if spans.is_empty() {
             Line::raw(String::new())
         } else {
@@ -217,18 +219,31 @@ fn is_link_reference_definition(s: &str) -> bool {
     !dest.is_empty() && dest.is_ascii() && !dest.contains(char::is_whitespace)
 }
 
-/// 判斷一行是原始 HTML 而非一般文字。
+/// 從 `open` 所在的 `<` 開始解析一個 HTML 標籤，回傳緊接在 `>` 之後的
+/// byte 索引。不是標籤則回傳 None。
 ///
-/// 光看 `<` 不夠：`<= 3 表示 ... > 0` 只是普通文字。
-/// 要求 `<` 後面緊接 ASCII 字母或 `/`，是能保留一般文字的低成本判斷法。
-fn is_html_block(s: &str) -> bool {
-    let t = s.trim();
-    let mut chars = t.chars();
-    if chars.next() != Some('<') {
-        return false;
+/// 光看 `<` 不夠，要求後面緊接 ASCII 字母或 `/`：`<= 3 表示 ... > 0` 只是
+/// 普通文字。另外要排掉 CommonMark autolink（`<https://x>`、`<a@b.com>`）——
+/// GitHub 會把它渲染成連結，刪掉等於吞掉一整條網址。判準是「裡面沒有空白、
+/// 而且有 `:` 或 `@`」：真正的標籤只要帶屬性就一定有空白（`<a href="…">`），
+/// 不帶屬性的（`<sup>`、`</a>`）則兩個字元都不會出現。
+///
+/// 屬性值裡含 `>`、標籤跨行都不處理——GitHub 與 bot 的實際輸出都不長那樣。
+///
+/// 回傳緊接在 `>` 之後的 byte 索引，以及標籤名與屬性之間的原文（`inner`）——
+/// 呼叫端要判斷是不是 `<br>` 時直接重用這段，不必再從頭剝一次角括號。
+fn parse_html_tag(text: &str, open: usize) -> Option<(usize, &str)> {
+    let rest = text.get(open + 1..)?;
+    let first = rest.chars().next()?;
+    if !(first.is_ascii_alphabetic() || first == '/') {
+        return None;
     }
-    let is_tag_start = matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '/');
-    is_tag_start && t.contains('>')
+    let close = rest.find('>')?;
+    let inner = &rest[..close];
+    if !inner.contains(char::is_whitespace) && (inner.contains(':') || inner.contains('@')) {
+        return None;
+    }
+    Some((open + 1 + close + 1, inner))
 }
 
 fn is_table_row(s: &str) -> bool {
@@ -453,23 +468,6 @@ fn wrap_cell(spans: &[Span<'static>], width: usize) -> Vec<Vec<Span<'static>>> {
     rows
 }
 
-fn str_width(s: &str) -> usize {
-    Span::raw(s).width()
-}
-
-/// 在保持寬度不超過 `max` 的前提下，找到最後一個字元邊界切開 `s`。
-fn split_at_width(s: &str, max: usize) -> (&str, &str) {
-    let mut w = 0usize;
-    for (i, c) in s.char_indices() {
-        let cw = str_width(c.encode_utf8(&mut [0u8; 4]));
-        if w + cw > max {
-            return s.split_at(i);
-        }
-        w += cw;
-    }
-    (s, "")
-}
-
 /// `1. rest` 或 `23. rest` → (含句點的前綴, rest)。不是有序列表則回傳 None。
 fn split_ordered_list(s: &str) -> Option<(&str, &str)> {
     let dot_pos = s.find('.')?;
@@ -482,7 +480,7 @@ fn split_ordered_list(s: &str) -> Option<(&str, &str)> {
 }
 
 /// 把一行文字拆成帶樣式的 span，處理 `**bold**`、`` `code` ``、
-/// `[text](url)`、`![alt](url)` 以及 HTML 實體。
+/// `[text](url)`、`![alt](url)`、HTML 標籤與 HTML 實體。
 /// 沒對上的文字變成一般 span。沒對上的標記符號原樣保留。
 fn scan_inline(text: &str) -> Vec<Span<'static>> {
     let mut spans: Vec<Span<'static>> = Vec::new();
@@ -511,6 +509,23 @@ fn scan_inline(text: &str) -> Vec<Span<'static>> {
                         .fg(Color::Blue)
                         .add_modifier(Modifier::UNDERLINED),
                 ));
+                i = end;
+                continue;
+            }
+        }
+        // 行內 HTML 標籤。Vercel 新版留言把 `<a><sup><img/></sup></a>` 塞進
+        // 表格儲存格，那條路徑只會走到這裡，行首判斷攔不到。
+        if bytes[i] == b'<' {
+            if let Some((end, inner)) = parse_html_tag(text, i) {
+                // `<br>`／`<br/>`／`<br />`：GitHub 表格儲存格靠它分行，剝掉
+                // 標籤時得留一個空白，否則 `foo<br>bar` 會黏成 `foobar`。
+                if inner
+                    .trim_end_matches('/')
+                    .trim()
+                    .eq_ignore_ascii_case("br")
+                {
+                    buf.push(' ');
+                }
                 i = end;
                 continue;
             }
@@ -783,6 +798,44 @@ mod tests {
     }
 
     #[test]
+    fn strips_inline_html_tags() {
+        let lines = render("前<b>粗</b>後<img src=\"x.svg\" alt=\"\" />尾");
+        assert_eq!(text_of(&lines[0]), "前粗後尾");
+    }
+
+    #[test]
+    fn br_becomes_a_space() {
+        // GitHub 的表格儲存格靠 `<br>` 分行，直接刪掉會把兩段文字黏在一起。
+        for body in ["a<br>b", "a<br/>b", "a<BR />b"] {
+            assert_eq!(text_of(&render(body)[0]), "a b", "{body}");
+        }
+    }
+
+    #[test]
+    fn keeps_autolinks() {
+        // CommonMark autolink，GitHub 會渲染成連結——不是可以吃掉的標籤。
+        let lines = render("see <https://example.com> and <a@b.com>");
+        assert_eq!(
+            text_of(&lines[0]),
+            "see <https://example.com> and <a@b.com>"
+        );
+    }
+
+    #[test]
+    fn generic_args_are_eaten_like_github_does() {
+        // `<String>` 在 GitHub 上也會被當標籤吃掉（沒加反引號的代價）。
+        // 刻意跟網頁行為一致，而不是自己發明一套。
+        assert_eq!(text_of(&render("Vec<String> 很長")[0]), "Vec 很長");
+    }
+
+    #[test]
+    fn keeps_inline_less_than_in_prose() {
+        // `<` 後面接非字母字元是算式，行中出現時跟行首一樣要留著。
+        let lines = render("條件是 a <= b 而且 c > d");
+        assert_eq!(text_of(&lines[0]), "條件是 a <= b 而且 c > d");
+    }
+
+    #[test]
     fn decodes_html_entities() {
         let lines = render("a &amp; b &lt;c&gt; &quot;d&quot; &#39;e&#39;");
         let text: String = lines[0]
@@ -949,5 +1002,43 @@ mod tests {
             "table row is {} wide: {table_row:?}",
             table_row.width()
         );
+    }
+
+    /// Vercel 後來改了留言格式，把專案圖示的 `<a><sup><img/></sup></a>` 直接
+    /// 塞進表格儲存格。這條路徑只走 `scan_inline`，不經過任何行首判斷——
+    /// 內容取自 scanoo-tw/scanoo-web#886 的實際留言。
+    #[test]
+    fn vercel_comment_with_inline_html_in_cells() {
+        let body = concat!(
+            "| Project | Deployment | Actions | Updated (UTC) |\n",
+            "| :--- | :----- | :------ | :------ |\n",
+            "| <a href=\"https://vercel.com/scanoo-projects/scanoo-web\"><sup>",
+            "<img src=\"https://vercel.com/api/www/avatar?projectId=prj_NEmNjGM9",
+            "&teamId=team_bm5Pz0v7wQhfmBkYpNmGGDpM&s=32\" width=\"16\" height=\"16\" ",
+            "align=\"middle\" alt=\"\" /></sup></a> ",
+            "[scanoo-web](https://vercel.com/scanoo-projects/scanoo-web) ",
+            "| ![Ready](https://vercel.com/static/status/ready.svg) ",
+            "[Ready](https://vercel.com/scanoo-projects/scanoo-web/ELwvvDg97wLQ) ",
+            "| [Preview](https://scanoo-web-git-issue-878-scanoo-projects.vercel.app) ",
+            "| Aug 9, 2026 12:24pm |\n",
+        );
+        let width = 46;
+        let lines = super::render(body, width);
+        let text: String = lines.iter().map(|l| text_of(l)).collect();
+
+        for leaked in ["<a", "href=", "<img", "<sup", "https://", "width="] {
+            assert!(!text.contains(leaked), "{leaked} leaked: {text:?}");
+        }
+        for kept in ["scanoo-web", "Ready", "Preview"] {
+            assert!(text.contains(kept), "{kept} missing: {text:?}");
+        }
+
+        // 拿掉圖示後，第一欄不能多出一個開頭空白把整欄往右推。
+        let row = lines
+            .iter()
+            .find(|l| l.spans.iter().any(|s| s.content.contains("scanoo-web")))
+            .expect("table row present");
+        assert_eq!(row.spans[0].content.as_ref(), "scanoo-web", "{row:?}");
+        assert!(row.width() <= width, "row is {} wide: {row:?}", row.width());
     }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -9,6 +9,7 @@ use ratatui::{
     style::{Color, Style},
     text::{Line, Span},
 };
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::{color::ColorTheme, event::UserEvent, keybind::KeyBind};
 
@@ -107,6 +108,23 @@ pub fn truncate_line(mut line: Line<'_>, max_width: usize) -> Line<'_> {
             used <= budget
         })
         .count();
+    if keep == 0 {
+        // 連第一個 span 都放不下。提示列到這裡整條清空是合理的（殘字看不懂），
+        // 但通知是單一 span（`Line::raw(msg)`），整條清空等於畫面上只剩一個
+        // `…`——git／gh 的錯誤訊息動輒上百字元，使用者會什麼都讀不到。退回
+        // 在字元邊界切，至少讀得到開頭。
+        let head = split_at_width(line.spans[0].content.as_ref(), budget)
+            .0
+            .to_string();
+        let style = line.spans[0].style;
+        line.spans.clear();
+        if !head.is_empty() {
+            line.spans.push(Span::styled(head, style));
+        }
+        line.spans.push(Span::raw(ELLIPSIS));
+        return line;
+    }
+
     line.spans.truncate(keep);
     line.spans.push(Span::raw(ELLIPSIS));
     line
@@ -114,6 +132,26 @@ pub fn truncate_line(mut line: Line<'_>, max_width: usize) -> Line<'_> {
 
 fn span_display_width(span: &Span<'_>) -> usize {
     console::measure_text_width(span.content.as_ref())
+}
+
+/// 在保持寬度不超過 `max` 的前提下，找到最後一個字元邊界切開 `s`。
+/// `truncate_line` 與 `markdown::wrap_cell` 共用同一份。
+pub(crate) fn split_at_width(s: &str, max: usize) -> (&str, &str) {
+    let mut w = 0usize;
+    for (i, c) in s.char_indices() {
+        let cw = c.width().unwrap_or(0);
+        if w + cw > max {
+            return s.split_at(i);
+        }
+        w += cw;
+    }
+    (s, "")
+}
+
+/// 跟 `span_display_width` 同樣的寬度計算，但省掉 ANSI 掃描——呼叫端
+/// （表格換行、單 span 截斷）處理的都是純文字。
+pub(crate) fn str_width(s: &str) -> usize {
+    s.width()
 }
 
 #[cfg(test)]
@@ -220,5 +258,22 @@ mod tests {
         let out = truncate_line(line.clone(), 0);
         assert_eq!(out.style, line.style);
         assert!(out.spans.is_empty());
+    }
+
+    /// 通知都是單一 span（`Line::raw(msg)`），單一 span 放不進 `budget`
+    /// 時原本會整條清空，只剩一個 `…`。窄終端上按 `C` 開連結會看到這個
+    /// 情況——退回在字元邊界切，至少讀得到開頭。
+    #[test]
+    fn truncate_single_span_falls_back_to_char_boundary() {
+        let line = Line::raw("SSH: https://github.com/scanoo/scanoo-web/pull/886");
+        let out = truncate_line(line, 12);
+        let text: String = out.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_ne!(text, ELLIPSIS, "應保留開頭而非整條清空：{text}");
+        assert!(text.starts_with("SSH:"), "{text}");
+        assert!(text.ends_with(ELLIPSIS), "{text}");
+        assert!(
+            console::measure_text_width(&text) <= 12,
+            "截斷後仍超寬：{text}"
+        );
     }
 }


### PR DESCRIPTION
## 變更摘要

- **status hints 格式**：按鍵不再硬寫進 desc 字串，拆成三組 `HintSpec` 讓 `hint_line` 正確上色；GitHub view 納入 `help.rs` 的提示一致性測試
- **Vercel HTML 留言**：`markdown.rs` 的 `scan_inline` 新增 `parse_html_tag` 剝除行內 HTML 標籤，處理 Vercel 新版留言把圖示塞進表格儲存格的情況；保留 autolink、`<br>` 轉空白，行為對齊 GitHub 對 `<Type>` 泛型語法的處理
- **SSH/mosh 開連結**：改印純文字 URL，不再用 OSC 8——mosh 的終端模擬器無法保存 hyperlink，tmux 的 DCS passthrough 會讓 label 印到錯位置並在畫面上留下殘骸；順手修掉 `truncate_line` 對單一長 span 通知會整條清空只剩省略號的問題
- 順手把測試裡「8 個攔截變體」的行內註解更正為 9（#50 加 `UpdatePrompt` 時漏改，與同檔 doc comment 互相矛盾）

已 rebase 到 `45ec3f4`（v2.5.0）。與 #50 的衝突集中在 `status_line.rs` 的變體計數：#50 加了 `UpdatePrompt`、本 PR 刪了 `NotificationHyperlink`，合併後 `StatusLine` 為 15 個變體、9 個攔截變體。

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test` 通過（436 passed / 0 failed）