### PR TITLE
refactor: truncate_line 兩條路徑併回一條，刪掉 str_width

### DIFF
--- a/src/view/markdown.rs
+++ b/src/view/markdown.rs
@@ -12,7 +12,9 @@ use ratatui::{
     text::{Line, Span},
 };
 
-use crate::widget::{split_at_width, str_width};
+use unicode_width::UnicodeWidthStr;
+
+use crate::widget::split_at_width;
 
 const RULE_WIDTH: usize = 40;
 
@@ -454,7 +456,7 @@ fn wrap_cell(spans: &[Span<'static>], width: usize) -> Vec<Vec<Span<'static>>> {
                 continue;
             }
             row.push(Span::styled(head.to_string(), span.style));
-            used += str_width(head);
+            used += head.width();
             rest = tail;
             if used >= width && !rest.is_empty() {
                 rows.push(std::mem::take(&mut row));

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -9,7 +9,7 @@ use ratatui::{
     style::{Color, Style},
     text::{Line, Span},
 };
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthChar;
 
 use crate::{color::ColorTheme, event::UserEvent, keybind::KeyBind};
 
@@ -116,16 +116,10 @@ pub fn truncate_line(mut line: Line<'_>, max_width: usize) -> Line<'_> {
         let head = split_at_width(line.spans[0].content.as_ref(), budget)
             .0
             .to_string();
-        let style = line.spans[0].style;
-        line.spans.clear();
-        if !head.is_empty() {
-            line.spans.push(Span::styled(head, style));
-        }
-        line.spans.push(Span::raw(ELLIPSIS));
-        return line;
+        line.spans[0].content = head.into();
     }
 
-    line.spans.truncate(keep);
+    line.spans.truncate(keep.max(1));
     line.spans.push(Span::raw(ELLIPSIS));
     line
 }
@@ -146,12 +140,6 @@ pub(crate) fn split_at_width(s: &str, max: usize) -> (&str, &str) {
         w += cw;
     }
     (s, "")
-}
-
-/// 跟 `span_display_width` 同樣的寬度計算，但省掉 ANSI 掃描——呼叫端
-/// （表格換行、單 span 截斷）處理的都是純文字。
-pub(crate) fn str_width(s: &str) -> usize {
-    s.width()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 變更摘要

`/simplify` 掃 `7f2433b` 後三個 agent 一致（3/3）認同的兩項，其餘建議因信號弱或 low priority 未納入。

- **`truncate_line` 的 `keep == 0` 分支併回主路徑**（`src/widget.rs`）——原本 `clear()` 掉 spans 再手動搬 `style` 重建，正是這個函式 doc comment 明文要避免的「逐欄位搬」；改成就地改第一個 span 的內容，收尾的 `truncate` / `push(ELLIPSIS)` 兩條路徑共用。第一個 span 必定存在（`spans` 為空時 `total == 0 <= max_width` 已提早 return）。唯一行為差異是 `max_width` 為 1~2 時會多留一個空內容 span，`Line::width()` 與畫面都不變
- **刪掉 `widget::str_width`**——它是 `UnicodeWidthStr::width` 的單一呼叫端別名，doc 裡列的第二個呼叫端「單 span 截斷」用的其實是 `split_at_width`、根本不存在；`markdown::wrap_cell` 改直接呼叫 `head.width()`（`unicode-width` 本來就是直接依賴）

對外行為不變，用 `refactor:` 不 bump 版號。

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --verbose` 通過（436 passed / 0 failed）