### PR TITLE
fix: gh CLI 呼叫加 timeout，並優化 GitHub 資料載入效率 (#57)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1277,8 +1277,23 @@ impl App<'_> {
 
         std::thread::spawn(move || {
             let state = filter.as_str();
-            let issues_result = crate::github::list_issues(&repo_path, state, None);
-            let prs_result = crate::github::list_pull_requests(&repo_path, state, None);
+            // 兩個查詢彼此獨立，改用 thread::scope 併發——序列跑今天要
+            // 2 個 gh 呼叫的 wall clock 疊加，併發只要較慢那個的時間。
+            let (issues_result, prs_result) = std::thread::scope(|s| {
+                let issues = s.spawn(|| crate::github::list_issues(&repo_path, state, None));
+                let prs = s.spawn(|| crate::github::list_pull_requests(&repo_path, state, None));
+                (issues.join(), prs.join())
+            });
+            // join() 回傳 Result<_, Box<dyn Any>>：thread panic 要轉成
+            // 錯誤訊息，不能讓它靜靜消失。今天 list_issues 若 panic，
+            // 整條 refresh thread 直接死掉、沒有任何事件送回主執行緒，
+            // GitHubLoad 永遠停在 Loading，之後每次 on_refresh_requested
+            // 都回 false——GitHub refresh 對這個 process 永久失效，不只
+            // 是這一次卡住，症狀跟這個 issue 要修的一模一樣。
+            let issues_result =
+                issues_result.unwrap_or_else(|_| Err("GitHub issues thread panicked".into()));
+            let prs_result =
+                prs_result.unwrap_or_else(|_| Err("GitHub PRs thread panicked".into()));
 
             let mut any_ok = false;
             let mut warnings = Vec::new();

--- a/src/app.rs
+++ b/src/app.rs
@@ -1279,21 +1279,23 @@ impl App<'_> {
             let state = filter.as_str();
             // 兩個查詢彼此獨立，改用 thread::scope 併發——序列跑今天要
             // 2 個 gh 呼叫的 wall clock 疊加，併發只要較慢那個的時間。
-            let (issues_result, prs_result) = std::thread::scope(|s| {
-                let issues = s.spawn(|| crate::github::list_issues(&repo_path, state, None));
-                let prs = s.spawn(|| crate::github::list_pull_requests(&repo_path, state, None));
-                (issues.join(), prs.join())
-            });
             // join() 回傳 Result<_, Box<dyn Any>>：thread panic 要轉成
             // 錯誤訊息，不能讓它靜靜消失。今天 list_issues 若 panic，
             // 整條 refresh thread 直接死掉、沒有任何事件送回主執行緒，
             // GitHubLoad 永遠停在 Loading，之後每次 on_refresh_requested
             // 都回 false——GitHub refresh 對這個 process 永久失效，不只
             // 是這一次卡住，症狀跟這個 issue 要修的一模一樣。
-            let issues_result =
-                issues_result.unwrap_or_else(|_| Err("GitHub issues thread panicked".into()));
-            let prs_result =
-                prs_result.unwrap_or_else(|_| Err("GitHub PRs thread panicked".into()));
+            let (issues_result, prs_result) = std::thread::scope(|s| {
+                let issues = s.spawn(|| crate::github::list_issues(&repo_path, state, None));
+                let prs = s.spawn(|| crate::github::list_pull_requests(&repo_path, state, None));
+                (
+                    issues
+                        .join()
+                        .unwrap_or_else(|_| Err("GitHub issues thread panicked".into())),
+                    prs.join()
+                        .unwrap_or_else(|_| Err("GitHub PRs thread panicked".into())),
+                )
+            });
 
             let mut any_ok = false;
             let mut warnings = Vec::new();

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
-use std::sync::{mpsc, LazyLock, Mutex};
+use std::sync::{mpsc, LazyLock, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 use rustc_hash::FxHashMap;
@@ -168,12 +168,8 @@ pub struct GitHubData {
 const GH_TIMEOUT: Duration = Duration::from_secs(20);
 const POLL_INTERVAL: Duration = Duration::from_millis(20);
 
-/// 把 pipe 讀到底丟進 channel。子行程被 kill 或自己結束都會讓 pipe 收到
-/// EOF，`read_to_end` 才會返回——但如果孫行程繼承了同一個寫端還活著，
-/// EOF 永遠不會來。呼叫端因此不能 `join` 這條 thread，只能用
-/// `recv_timeout` 有界地等，逾時就當空輸出，thread 留著讓它自生自滅
-/// （pipe 最終關閉時它自然結束；就算沒有，代價是一條閒置 thread，
-/// 不是一個廢掉的呼叫）。
+/// 把 pipe 讀到底丟進 channel；呼叫端只能用 `recv_timeout` 有界地等，
+/// 不能 `join`（理由見 `run_with_timeout`）。
 fn spawn_reader<R: Read + Send + 'static>(mut pipe: R) -> mpsc::Receiver<Vec<u8>> {
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
@@ -229,25 +225,22 @@ fn run_with_timeout(
 
     let deadline = Instant::now() + timeout;
     let status = loop {
-        match child.try_wait() {
+        let failure = match child.try_wait() {
             Ok(Some(status)) => break status,
-            Ok(None) if Instant::now() < deadline => std::thread::sleep(POLL_INTERVAL),
-            Ok(None) => {
-                let _ = child.kill();
-                let _ = child.wait(); // reap，不留 zombie；不等 reader thread
-                return Err(format!(
-                    "{program} command timed out after {}s (network issue?)",
-                    timeout.as_secs()
-                ));
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(POLL_INTERVAL);
+                continue;
             }
-            Err(e) => {
-                // try_wait 本身失敗（極罕見）也要走同一條收尾：kill+reap，
-                // 不留下沒清理的子行程。
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(format!("Failed to wait for {program}: {e}"));
-            }
-        }
+            Ok(None) => format!(
+                "{program} command timed out after {}s (network issue?)",
+                timeout.as_secs()
+            ),
+            // try_wait 本身失敗（極罕見）也走同一條收尾。
+            Err(e) => format!("Failed to wait for {program}: {e}"),
+        };
+        let _ = child.kill();
+        let _ = child.wait(); // reap，不留 zombie；不等 reader thread
+        return Err(failure);
     };
 
     // 子行程自己結束了（不是被我們 kill），但孫行程可能仍握著 pipe 寫端
@@ -343,30 +336,21 @@ pub fn list_issues(
 static REPO_NAME_CACHE: LazyLock<Mutex<FxHashMap<PathBuf, (String, String)>>> =
     LazyLock::new(|| Mutex::new(FxHashMap::default()));
 
-/// 鎖只圈住 HashMap 存取，**絕不橫跨 `run_gh`**：`run_gh` 現在最長會跑滿
-/// `GH_TIMEOUT`（20 秒），持鎖跑它的話網路死掉時第二個 caller 要先等
-/// 20 秒拿鎖、再跑自己的 20 秒，最壞情況直接翻倍——這個函式存在的目的
-/// 就是不讓等待時間被放大。而且 `get_timeline`（使用者按進 issue 詳情
-/// 的同步路徑）會被排到背景 refresh 的死網路後面，那是明確的回歸。
-///
-/// 代價：process 生命週期內最多一次多餘的 `gh repo view`（只有兩條
-/// thread 剛好同時第一次進來才發生，而且它們是併發的，wall clock 不變）。
-/// 用一次 API 額度換「任何 caller 都不會被別人的網路卡住」，划算。
-///
-/// 已知取捨：快取在 process 生命週期內永不失效——使用者中途跑
-/// `gh repo set-default` 或 `git remote set-url` 改掉 base repo，會拿到
-/// 舊值直到重啟。這是罕見動作，可接受。
-///
-/// `lock()` 用 `unwrap_or_else(|e| e.into_inner())` 而不是 `expect`：
-/// 快取不需要 poisoning 語意，毒化了照樣可以用。用 `expect` 的話，
-/// 任何一次 panic 都會讓這個 process 之後每一次 GitHub 呼叫都 panic，
-/// GitHub 功能永久壞掉還看起來像網路問題。
+/// 不用 `expect`：快取不需要 poisoning 語意，毒化了照樣可以用。用
+/// `expect` 的話，任何一次 panic 都會讓這個 process 之後每一次 GitHub
+/// 呼叫都 panic，GitHub 功能永久壞掉還看起來像網路問題。
+fn repo_name_cache() -> MutexGuard<'static, FxHashMap<PathBuf, (String, String)>> {
+    REPO_NAME_CACHE.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// **絕不持鎖橫跨 `run_gh`**：`run_gh` 現在最長會跑滿 `GH_TIMEOUT`
+/// （20 秒），持鎖跑它的話網路死掉時第二個 caller 要先等 20 秒拿鎖、
+/// 再跑自己的 20 秒，最壞情況直接翻倍——這個函式存在的目的就是不讓
+/// 等待時間被放大。代價：process 生命週期內最多一次多餘的
+/// `gh repo view`；快取在 process 生命週期內不失效（中途改 base repo
+/// 要重啟才生效，罕見動作，可接受）。
 fn fetch_repo_name_with_owner(path: &Path) -> Result<(String, String), String> {
-    if let Some(hit) = REPO_NAME_CACHE
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .get(path)
-    {
+    if let Some(hit) = repo_name_cache().get(path) {
         return Ok(hit.clone());
     }
 
@@ -385,13 +369,10 @@ fn fetch_repo_name_with_owner(path: &Path) -> Result<(String, String), String> {
     let (owner, name) = s
         .split_once('/')
         .ok_or_else(|| format!("Unexpected nameWithOwner: {s}"))?;
-    let (owner, name) = (owner.to_string(), name.to_string());
+    let entry = (owner.to_string(), name.to_string());
 
-    REPO_NAME_CACHE
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .insert(path.to_path_buf(), (owner.clone(), name.clone()));
-    Ok((owner, name))
+    repo_name_cache().insert(path.to_path_buf(), entry.clone());
+    Ok(entry)
 }
 
 fn parse_issues_graphql(json: &str) -> Result<GhPage<GhIssue>, String> {

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,9 +1,10 @@
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
-use std::sync::mpsc;
+use std::sync::{mpsc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Deserializer};
 
 /// 反序列化時就把 emoji shortcode 展開。掛在欄位定義上而不是在 `into_gh_*` 裡逐處
@@ -332,7 +333,43 @@ pub fn list_issues(
     parse_issues_graphql(&json)
 }
 
+/// key 是 repo path，value 是 `(owner, name)`。只快取成功結果——第一次
+/// 因為沒網路失敗時不能把失敗記起來，否則這個 process 之後再也不會重試。
+///
+/// 用 map 而不是 `OnceLock`：實務上這個 process 只服務一個 repo
+/// （`lib.rs` 只 `Repository::load` 一次），但 `path` 是這個函式的參數，
+/// 用 `OnceLock` 等於對簽名說謊——哪天真的有第二個 path 進來會安靜地
+/// 回錯的值。
+static REPO_NAME_CACHE: LazyLock<Mutex<FxHashMap<PathBuf, (String, String)>>> =
+    LazyLock::new(|| Mutex::new(FxHashMap::default()));
+
+/// 鎖只圈住 HashMap 存取，**絕不橫跨 `run_gh`**：`run_gh` 現在最長會跑滿
+/// `GH_TIMEOUT`（20 秒），持鎖跑它的話網路死掉時第二個 caller 要先等
+/// 20 秒拿鎖、再跑自己的 20 秒，最壞情況直接翻倍——這個函式存在的目的
+/// 就是不讓等待時間被放大。而且 `get_timeline`（使用者按進 issue 詳情
+/// 的同步路徑）會被排到背景 refresh 的死網路後面，那是明確的回歸。
+///
+/// 代價：process 生命週期內最多一次多餘的 `gh repo view`（只有兩條
+/// thread 剛好同時第一次進來才發生，而且它們是併發的，wall clock 不變）。
+/// 用一次 API 額度換「任何 caller 都不會被別人的網路卡住」，划算。
+///
+/// 已知取捨：快取在 process 生命週期內永不失效——使用者中途跑
+/// `gh repo set-default` 或 `git remote set-url` 改掉 base repo，會拿到
+/// 舊值直到重啟。這是罕見動作，可接受。
+///
+/// `lock()` 用 `unwrap_or_else(|e| e.into_inner())` 而不是 `expect`：
+/// 快取不需要 poisoning 語意，毒化了照樣可以用。用 `expect` 的話，
+/// 任何一次 panic 都會讓這個 process 之後每一次 GitHub 呼叫都 panic，
+/// GitHub 功能永久壞掉還看起來像網路問題。
 fn fetch_repo_name_with_owner(path: &Path) -> Result<(String, String), String> {
+    if let Some(hit) = REPO_NAME_CACHE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(path)
+    {
+        return Ok(hit.clone());
+    }
+
     let out = run_gh(
         path,
         &[
@@ -348,7 +385,13 @@ fn fetch_repo_name_with_owner(path: &Path) -> Result<(String, String), String> {
     let (owner, name) = s
         .split_once('/')
         .ok_or_else(|| format!("Unexpected nameWithOwner: {s}"))?;
-    Ok((owner.to_string(), name.to_string()))
+    let (owner, name) = (owner.to_string(), name.to_string());
+
+    REPO_NAME_CACHE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(path.to_path_buf(), (owner.clone(), name.clone()));
+    Ok((owner, name))
 }
 
 fn parse_issues_graphql(json: &str) -> Result<GhPage<GhIssue>, String> {

--- a/src/github.rs
+++ b/src/github.rs
@@ -161,12 +161,9 @@ pub struct GitHubData {
 
 // ── CLI 包裝 ──
 
-fn run_gh(path: &Path, args: &[&str], force_tty: bool) -> Result<String, String> {
+fn run_gh(path: &Path, args: &[&str]) -> Result<String, String> {
     let mut cmd = Command::new("gh");
     cmd.args(args).current_dir(path).stdin(Stdio::null());
-    if force_tty {
-        cmd.env("GH_FORCE_TTY", "200");
-    }
 
     let output = cmd
         .output()
@@ -219,7 +216,7 @@ pub fn list_issues(
         args.push("-f");
         args.push(&after_f);
     }
-    let json = run_gh(path, &args, false)?;
+    let json = run_gh(path, &args)?;
     parse_issues_graphql(&json)
 }
 
@@ -234,7 +231,6 @@ fn fetch_repo_name_with_owner(path: &Path) -> Result<(String, String), String> {
             "--jq",
             ".nameWithOwner",
         ],
-        false,
     )?;
     let s = out.trim();
     let (owner, name) = s
@@ -378,7 +374,7 @@ pub fn list_pull_requests(
         args.push("-f");
         args.push(&after_f);
     }
-    let json = run_gh(path, &args, false)?;
+    let json = run_gh(path, &args)?;
     parse_prs_graphql(&json)
 }
 
@@ -588,7 +584,7 @@ pub fn get_timeline(
         args.push("-f");
         args.push(&after_f);
     }
-    let json = run_gh(path, &args, false)?;
+    let json = run_gh(path, &args)?;
     parse_timeline_graphql(&json, kind)
 }
 
@@ -668,7 +664,6 @@ pub fn get_body(path: &Path, number: u64, kind: GhItemKind) -> Result<String, St
             "--jq",
             ".body",
         ],
-        false,
     )
 }
 
@@ -830,11 +825,7 @@ pub fn set_item_state(
     number: u64,
     action: StateAction,
 ) -> Result<(), String> {
-    run_gh(
-        path,
-        &[kind.as_str(), action.verb(), &number.to_string()],
-        false,
-    )?;
+    run_gh(path, &[kind.as_str(), action.verb(), &number.to_string()])?;
     Ok(())
 }
 
@@ -871,7 +862,7 @@ pub fn merge_pr(path: &Path, number: u64, method: &str, delete_branch: bool) -> 
     if delete_branch {
         args.push("--delete-branch");
     }
-    run_gh(path, &args, false)?;
+    run_gh(path, &args)?;
     Ok(())
 }
 
@@ -935,7 +926,7 @@ pub fn set_pr_draft(path: &Path, number: u64, action: PrDraftAction) -> Result<(
     if action.result_is_draft() {
         args.push("--undo");
     }
-    run_gh(path, &args, false)?;
+    run_gh(path, &args)?;
     Ok(())
 }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,5 +1,8 @@
+use std::io::{Read, Write};
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::{Command, Output, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Deserializer};
 
@@ -161,13 +164,122 @@ pub struct GitHubData {
 
 // ── CLI 包裝 ──
 
+const GH_TIMEOUT: Duration = Duration::from_secs(20);
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// 把 pipe 讀到底丟進 channel。子行程被 kill 或自己結束都會讓 pipe 收到
+/// EOF，`read_to_end` 才會返回——但如果孫行程繼承了同一個寫端還活著，
+/// EOF 永遠不會來。呼叫端因此不能 `join` 這條 thread，只能用
+/// `recv_timeout` 有界地等，逾時就當空輸出，thread 留著讓它自生自滅
+/// （pipe 最終關閉時它自然結束；就算沒有，代價是一條閒置 thread，
+/// 不是一個廢掉的呼叫）。
+fn spawn_reader<R: Read + Send + 'static>(mut pipe: R) -> mpsc::Receiver<Vec<u8>> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = pipe.read_to_end(&mut buf);
+        let _ = tx.send(buf);
+    });
+    rx
+}
+
+/// 逾時就砍掉的子行程執行，`run_gh`（純讀，`stdin_data = None`）跟
+/// `update_body`（要把 body 灌進 stdin，`stdin_data = Some(body)`）共用。
+///
+/// **函式內部唯一的等待機制是 `deadline`，沒有任何 `join()`**——`gh` 常會
+/// fork 出 `git` 之類的孫行程，`kill()` 只殺得掉 `gh` 自己，孫行程繼承的
+/// pipe 寫端沒關，reader thread 永遠等不到 EOF，`join()` 會卡死——這正好
+/// 是「有子行程掛在網路上」的情境，也就是這個函式最該生效的那個情境。
+/// 改用 `spawn_reader` + `recv_timeout(剩餘預算)`，不管子行程是被我們
+/// kill、還是自己結束但孫行程仍握著 pipe，都保證在 `timeout` 內返回。
+fn run_with_timeout(
+    mut cmd: Command,
+    stdin_data: Option<&[u8]>,
+    timeout: Duration,
+) -> Result<Output, String> {
+    let program = cmd.get_program().to_string_lossy().into_owned();
+    cmd.stdin(if stdin_data.is_some() {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    })
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to execute {program}: {e}"))?;
+
+    if let Some(data) = stdin_data {
+        // 射後不理：唯一的副作用是寫完 drop 掉 `stdin`，讓子行程收到
+        // EOF。不能等它——它可能跟 reader thread 一樣卡在孫行程手上。
+        let mut stdin = child
+            .stdin
+            .take()
+            .expect("stdin is piped when stdin_data is Some");
+        let data = data.to_vec();
+        std::thread::spawn(move || {
+            let _ = stdin.write_all(&data);
+        });
+    }
+
+    let stdout_rx = spawn_reader(child.stdout.take().expect("stdout is piped"));
+    let stderr_rx = spawn_reader(child.stderr.take().expect("stderr is piped"));
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < deadline => std::thread::sleep(POLL_INTERVAL),
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait(); // reap，不留 zombie；不等 reader thread
+                return Err(format!(
+                    "{program} command timed out after {}s (network issue?)",
+                    timeout.as_secs()
+                ));
+            }
+            Err(e) => {
+                // try_wait 本身失敗（極罕見）也要走同一條收尾：kill+reap，
+                // 不留下沒清理的子行程。
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("Failed to wait for {program}: {e}"));
+            }
+        }
+    };
+
+    // 子行程自己結束了（不是被我們 kill），但孫行程可能仍握著 pipe 寫端
+    // 不放——用剩餘的 timeout 預算等 reader，逾時就當空輸出，不能無界等
+    // （這條路徑對應 `Command::output()`／`wait_with_output()` 今天就有
+    // 的同一個理論限制，這裡額外把它也收進同一個 deadline 預算裡）。
+    //
+    // 每次都要重算剩餘預算：算一次餵給兩個 `recv_timeout` 的話，子行程
+    // 一結束就 break（剩餘 ≈ 整個 timeout）時兩次各可耗滿，總共變成
+    // 2×timeout。（`Receiver::recv_deadline()` 能一步到位，但還是
+    // unstable，rust-lang/rust#46316，不能用。）
+    //
+    // 逾時當空輸出的後果：`run_gh` 會把空字串餵給 `parse_issues_graphql`，
+    // 使用者看到的是 JSON parse error 而不是 timed out 訊息。不改成回報
+    // 錯誤是因為 `update_body` 根本不需要 stdout，強制報錯會對「其實
+    // 成功了」的編輯回報假錯誤，而 checkbox toggle 不冪等，使用者重試
+    // 會把狀態弄反——回假成功比回假失敗安全。
+    let remaining = || deadline.saturating_duration_since(Instant::now());
+    let stdout = stdout_rx.recv_timeout(remaining()).unwrap_or_default();
+    let stderr = stderr_rx.recv_timeout(remaining()).unwrap_or_default();
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
 fn run_gh(path: &Path, args: &[&str]) -> Result<String, String> {
     let mut cmd = Command::new("gh");
-    cmd.args(args).current_dir(path).stdin(Stdio::null());
+    cmd.args(args).current_dir(path);
 
-    let output = cmd
-        .output()
-        .map_err(|e| format!("Failed to execute gh: {e}"))?;
+    let output = run_with_timeout(cmd, None, GH_TIMEOUT)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -728,21 +840,11 @@ pub fn toggle_checkboxes(body: &str, indices: &[usize]) -> String {
 
 pub fn update_body(path: &Path, number: u64, kind: GhItemKind, body: &str) -> Result<(), String> {
     let num_str = number.to_string();
-    let output = Command::new("gh")
-        .args([kind.as_str(), "edit", &num_str, "--body-file", "-"])
-        .current_dir(path)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .and_then(|mut child| {
-            use std::io::Write;
-            if let Some(ref mut stdin) = child.stdin {
-                stdin.write_all(body.as_bytes())?;
-            }
-            child.wait_with_output()
-        })
-        .map_err(|e| format!("Failed to execute gh: {e}"))?;
+    let mut cmd = Command::new("gh");
+    cmd.args([kind.as_str(), "edit", &num_str, "--body-file", "-"])
+        .current_dir(path);
+
+    let output = run_with_timeout(cmd, Some(body.as_bytes()), GH_TIMEOUT)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -933,6 +1035,66 @@ pub fn set_pr_draft(path: &Path, number: u64, action: PrDraftAction) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── run_with_timeout() ──
+    //
+    // 所有逾時測試共用的預算與斷言上限。上限抓 3 倍而不是「反正很大」的
+    // 2 秒：這幾條測試唯一的價值就是證明「有界」，斷言鬆到跟預算無關就
+    // 什麼都沒證明。
+
+    const BUDGET: Duration = Duration::from_millis(150);
+    const MAX_ELAPSED: Duration = Duration::from_millis(450);
+
+    #[test]
+    fn run_with_timeout_pipes_stdin_and_captures_stdout() {
+        let output = run_with_timeout(
+            Command::new("cat"),
+            Some(b"hello\n"),
+            Duration::from_secs(5),
+        )
+        .expect("cat should succeed");
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"hello\n");
+    }
+
+    #[test]
+    fn run_with_timeout_kills_a_directly_hanging_child() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30");
+        let start = Instant::now();
+        let err = run_with_timeout(cmd, None, BUDGET).expect_err("sleep 30 should time out");
+        assert!(err.contains("timed out"), "{err}");
+        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
+    }
+
+    #[test]
+    fn run_with_timeout_does_not_hang_when_a_killed_childs_orphan_still_holds_the_pipe() {
+        // sh 自己因為 `wait` 卡住 30 秒（觸發 kill），但它背景起的 sleep
+        // 繼承了同一組 stdout/stderr 寫端——kill 掉 sh 不會連帶殺掉 sleep，
+        // 這正是 join() 版本會卡死的情境，即使子行程本身已經被砍掉、reap 掉。
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 30 & wait"]);
+        let start = Instant::now();
+        let err = run_with_timeout(cmd, None, BUDGET)
+            .expect_err("should time out even though a grandchild still holds the pipe open");
+        assert!(err.contains("timed out"), "{err}");
+        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
+    }
+
+    #[test]
+    fn run_with_timeout_does_not_exceed_budget_when_child_exits_but_orphan_holds_the_pipe() {
+        // sh 沒有 `wait`，立刻結束（成功路徑，不會觸發 kill）；但背景的
+        // sleep 一樣繼承了 pipe 寫端還活著。這條是「remaining 算一次用
+        // 兩次」的迴歸測試：那個寫法在這裡會花掉 2×BUDGET，每次重算才會
+        // 落在 BUDGET 附近。
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 30 &"]);
+        let start = Instant::now();
+        let output = run_with_timeout(cmd, None, BUDGET)
+            .expect("sh itself exits immediately, this should not error");
+        assert!(output.status.success());
+        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
+    }
 
     /// 狀態 → 動作的映射是 hint 與實際動作的唯一來源，錯了兩邊會一起錯。
     #[test]


### PR DESCRIPTION
## 變更摘要

- **修 bug**：`run_gh()`／`update_body()` 呼叫外部 `gh` CLI 完全沒有逾時保護，
  `gh` 卡住（網路慢、DNS、rate limit）時會無限期阻塞背景 thread，畫面永遠
  停在「Loading GitHub data...」。新增 `run_with_timeout()`，20 秒逾時強制
  `kill` 子行程；用 `mpsc::Receiver::recv_timeout` 收集輸出而非 `join()`——
  `gh` 常會 fork 出 `git` 之類的孫行程，`kill()` 殺不掉孫行程，用 `join()`
  收 reader thread 會在這個情境卡死，剛好是這個修復最該生效的情境
- **效率優化**（使用者追問後一併處理，實測同一 repo 從 ~3.0 秒降到
  ~0.6 秒）：
  - `fetch_repo_name_with_owner` 加快取——同一個 repo 的 owner/name 是
    process 生命週期內的常數，卻每次都重新打一次網路（~550ms／次）。
    鎖不橫跨 `run_gh`，避免網路死掉時把等待時間放大
  - `refresh_github` 的 issues／PRs 兩個獨立查詢改用 `thread::scope`
    併發，順帶修掉一個既有 bug：任一查詢 panic 會讓 refresh thread
    直接死掉、GitHub refresh 對整個 process 永久失效
- 順手砍掉 `run_gh` 的死參數 `force_tty`（8 個呼叫點從沒人傳過 `true`）
- `/simplify` 已跑過三個 review agent 並套用結果

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --verbose` 通過（451 個 lib 測試，含 4 個逾時情境的
      sub-second 自動化測試：直接卡住、孫行程握住 pipe 造成 kill 後仍
      卡住、子行程自己結束但孫行程握住 pipe、以及 2×timeout 迴歸測試）
- [x] 對真實 repo 端到端量測：序列/冷快取 1.84s → 序列/熱快取 1.21s →
      平行/熱快取 0.59s，資料正確載入
- [ ] 手動驗證：`PATH` 上把 `gh` 換成 `sleep 60` wrapper script，確認
      20 秒後 UI 出現 warning 且沒有殘留的 `gh` 行程（尚待在互動終端機
      驗證，自動化測試已用參數化 timeout 涵蓋同一段程式碼路徑）

Closes #57