### PR TITLE
ci: 版號規範補齊 11 種 type，格式檢查前移到 lefthook 與 PR 標題

### DIFF
--- a/.github/scripts/check_subject.py
+++ b/.github/scripts/check_subject.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""檢查 commit subject（或 PR 標題）符合 conventional commit 規範。
+
+兩個呼叫端共用同一份判斷，規範只有一份定義（`prepare_release.py` 的
+`TYPE_TABLE` 與 `subject_problem()`）：
+
+- `lefthook.yml` 的 commit-msg hook：`check_subject.py <COMMIT_EDITMSG 路徑>`
+- `.github/workflows/pr-title.yml`：`check_subject.py --text "<PR 標題>"`
+
+兩邊都要檢查的理由見 CONTRIBUTING.md「Commit 訊息」。
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from prepare_release import TYPE_TABLE, subject_problem
+
+# git 自己產生的訊息，不是人打的，不該被規範擋下來——硬擋只會逼人加
+# `--no-verify`，那等於整個 hook 失效。
+#
+# `Revert` / `Reapply` 帶著雙引號比對，是因為 git 產的一定長這樣
+# （`Reapply "…"` 是 2.42 之後 revert 一個 revert 的預設訊息）。少了引號，
+# 「Revert 掉自動更新功能」這種人手打、真的沒有前綴的 subject 會被誤放行。
+GIT_GENERATED_PREFIXES = (
+    "Merge ",
+    'Revert "',
+    'Reapply "',
+    "fixup! ",
+    "squash! ",
+    "amend! ",
+)
+
+
+def first_meaningful_line(text: str) -> str:
+    """取第一行非註解、非空白的內容。
+
+    `COMMIT_EDITMSG` 開頭可能是 git 的說明註解（`# Please enter…`），
+    也可能是使用者自己寫在前面的註解行。
+    """
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped
+    return ""
+
+
+def check(subject: str) -> str | None:
+    """回傳錯誤訊息，通過則 `None`。"""
+    if not subject:
+        return "commit 訊息是空的"
+    if subject.startswith(GIT_GENERATED_PREFIXES):
+        return None
+    return subject_problem(subject)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", help="commit 訊息檔（COMMIT_EDITMSG）")
+    parser.add_argument("--text", help="直接檢查這段文字，而不是讀檔")
+    args = parser.parse_args()
+
+    if args.text is not None:
+        subject = args.text.strip()
+    elif args.path:
+        subject = first_meaningful_line(Path(args.path).read_text(encoding="utf-8"))
+    else:
+        parser.error("要給 commit 訊息檔路徑，或用 --text 直接給字串")
+
+    problem = check(subject)
+    if problem is None:
+        return 0
+
+    print(
+        f"commit subject 不符規範：{subject}\n"
+        f"  ↳ {problem}\n\n"
+        f"格式：<type>: <中文描述> (#issue)\n"
+        f"可用 type：{'／'.join(TYPE_TABLE)}\n"
+        "範例：fix: gh CLI 呼叫加 timeout (#57)\n\n"
+        "詳見 CONTRIBUTING.md「Commit 訊息」。",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -25,12 +25,26 @@ CARGO_LOCK = REPO_ROOT / "Cargo.lock"
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 
 # commit type -> (CHANGELOG section 標題, bump 等級)。等級為 None 代表該
-# type 有專屬 CHANGELOG 區塊，但本身不觸發版號變動（例如 refactor）。
+# type 有專屬 CHANGELOG 區塊，但本身不觸發版號變動。
+#
+# 判準是「這個 commit 有沒有改到使用者下載的那個執行檔」：有就至少 patch，
+# 沒有就只列 CHANGELOG。所以 refactor／style／build／revert 都算 patch
+# （原始碼或相依變了，產出的 binary 就不是同一個），而 docs／test／ci／
+# chore 不算（純文件、測試、CI 設定、雜務不會進 binary）。
+#
+# 改這張表要同步更新 CONTRIBUTING.md 的對照表——那是給貢獻者看的第二份。
 TYPE_TABLE = {
     "feat": ("Features", "minor"),
     "fix": ("Bug Fixes", "patch"),
     "perf": ("Performance", "patch"),
-    "refactor": ("Refactors", None),
+    "refactor": ("Refactors", "patch"),
+    "revert": ("Reverts", "patch"),
+    "build": ("Build System", "patch"),
+    "style": ("Styles", "patch"),
+    "docs": ("Documentation", None),
+    "test": ("Tests", None),
+    "ci": ("CI", None),
+    "chore": ("Chores", None),
 }
 # CHANGELOG section 順序沿用 TYPE_TABLE 的宣告順序，不手抄第二份——新增
 # commit type 時只要改上面那張表，這裡自動跟著變，不會漏同步。
@@ -103,6 +117,35 @@ def build_pr_map(base: str) -> dict[str, int]:
     return pr_map
 
 
+def warn(message: str) -> None:
+    """留一則警告。在 GitHub Actions 上是 annotation，本機是普通 stderr。
+
+    一律走 stderr：runner 兩條串流都會解析 workflow command，而 stdout 有
+    別的用途——`--print-section` 的輸出會被重導向成 GitHub Release 內文
+    （見 `release.yml` 的 upload job），警告混進去就會出現在發版說明裡。
+    """
+    prefix = "::warning::" if os.environ.get("GITHUB_ACTIONS") else "warning: "
+    print(f"{prefix}{message}", file=sys.stderr)
+
+
+def subject_problem(subject: str) -> str | None:
+    """回傳 subject 不符規範的原因，符合就回 `None`。
+
+    純函式、不碰 git，`test_prepare_release.py` 直接餵字串測。
+
+    這是規範的唯一定義，三個呼叫端共用：lefthook 的 commit-msg hook 與
+    PR 標題 lint（兩者經 `check_subject.py`）在 merge 前擋，`classify()`
+    則只是補一則警告——擋在那裡沒有用，commit 已經在 main 上了。
+    """
+    m = SUBJECT_RE.match(subject)
+    if not m:
+        return "缺少 conventional commit 前綴（`type: 描述`）"
+    ctype = m.group("type")
+    if ctype not in TYPE_TABLE:
+        return f"`{ctype}` 不是認得的 commit type"
+    return None
+
+
 def classify(
     commits: list[Commit],
 ) -> tuple[str | None, dict[str, list[tuple[Commit, str]]], list[tuple[Commit, str]]]:
@@ -112,10 +155,16 @@ def classify(
     breaking: list[tuple[Commit, str]] = []
 
     for c in commits:
+        # 格式不合只警告不中止，理由見 subject_problem()。
         m = SUBJECT_RE.match(c.subject)
-        if not m:
+        entry = TYPE_TABLE.get(m.group("type")) if m else None
+        if entry is None:
+            warn(
+                f"{c.hash[:7]} {c.subject} ↳ {subject_problem(c.subject)}"
+                "（不列入 CHANGELOG 與版號計算）"
+            )
             continue
-        ctype = m.group("type")
+
         desc = m.group("desc").strip()
         is_breaking = bool(m.group("breaking"))
 
@@ -128,10 +177,8 @@ def classify(
         elif is_breaking:
             breaking.append((c, desc))
 
-        entry = TYPE_TABLE.get(ctype)
-        section, own_level = entry if entry else (None, None)
-        if section:
-            sections[section].append((c, desc))
+        section, own_level = entry
+        sections[section].append((c, desc))
 
         level = "major" if is_breaking else own_level
         if BUMP_RANK[level] > BUMP_RANK[bump]:
@@ -305,6 +352,13 @@ def main() -> int:
     bump, sections, breaking = classify(commits)
 
     if bump is None:
+        # 沒有這則警告，「發版」與「漏發版」在 run 頁面上長得一模一樣，
+        # 都是綠燈——只能等有人發現 tag 沒出來。
+        quiet = "／".join(t for t, (_, level) in TYPE_TABLE.items() if level is None)
+        warn(
+            f"這次 push 沒有觸發發版：{args.base}..HEAD 的 {len(commits)} 個 commit "
+            f"沒有任何一個會升版號（只有 {quiet} 這類，或格式不合被略過）。"
+        )
         print("NO_BUMP")
         return 0
 

--- a/.github/scripts/test_prepare_release.py
+++ b/.github/scripts/test_prepare_release.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""發版腳本的測試。直接跑：`python3 .github/scripts/test_prepare_release.py`。
+
+不用 pytest——這個 repo 沒有 Python 的開發相依，為了幾十行斷言引進一套
+測試框架不划算。CI 在 build.yml 裡跑同一行。
+
+測的都是純函式（吃字串、吐結果，不碰 git 也不碰檔案系統）。會動到 git 的
+`load_commits` / `build_pr_map` 不在這裡測——它們是薄薄一層 subprocess 包裝，
+真正的邏輯都在被測的這幾個函式裡。
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sys
+
+# 有幾條測試餵的是格式不合的 subject，會走進 `classify()` 的 `warn()`。
+# 在 Actions 上 `warn()` 印的是 `::warning::` 工作流程指令，runner 會把它
+# 收成一則真的 annotation——這次改動的重點就是讓 warning 有訊號，測試自己
+# 每跑一次就放一則假的進去剛好把訊號洗掉。先摘掉這個環境變數。
+os.environ.pop("GITHUB_ACTIONS", None)
+
+from check_subject import check, first_meaningful_line  # noqa: E402
+from prepare_release import (  # noqa: E402
+    BUMP_RANK,
+    TYPE_TABLE,
+    Commit,
+    build_changelog_block,
+    bump_version,
+    classify,
+    subject_problem,
+)
+
+failures: list[str] = []
+
+
+def expect(cond: bool, what: str) -> None:
+    if not cond:
+        failures.append(what)
+
+
+def c(subject: str, body: str = "") -> Commit:
+    """測試用 commit。hash 只要長度像樣即可，內容不影響被測邏輯。"""
+    return Commit("0" * 40, subject, body)
+
+
+# --- subject_problem：格式判斷 -------------------------------------------
+
+for good in [
+    "fix: 修正某個東西 (#57)",
+    "feat: 新功能",
+    "refactor: 重整 (#60) (#64)",
+    "feat!: 破壞相容",
+    "fix(config): 帶 scope",
+    "chore: release v2.7.2",
+]:
+    expect(subject_problem(good) is None, f"應該通過卻被擋：{good}")
+
+for bad in [
+    "TOML 架構重整 (#64)",  # 就是這次事故的形狀：完全沒有前綴
+    "Fix: 首字大寫",
+    "chroe: type 打錯字",
+    "隨手改一下",
+    "",
+]:
+    expect(subject_problem(bad) is not None, f"應該被擋卻通過：{bad}")
+
+
+# --- check：git 自己產生的訊息要放行，人手打的不行 ------------------------
+
+for generated in [
+    'Revert "fix: 某個修正 (#12)"',
+    'Reapply "fix: 某個修正 (#12)"',  # git 2.42+ revert 一個 revert
+    "fixup! fix: 某個修正",
+    "squash! feat: 新功能",
+    "Merge branch 'main' into feature",
+    "Merge pull request #64 from YSzEthan/26081201",
+]:
+    expect(check(generated) is None, f"git 產生的訊息不該被擋：{generated}")
+
+# 白名單是靠雙引號認出 git 的手筆，人手打的同字開頭不該混進去
+for human in ["Revert 掉自動更新功能", "Reapply 那個設定"]:
+    expect(check(human) is not None, f"人手打的無前綴 subject 不該放行：{human}")
+
+expect(check("") is not None, "空訊息應該被擋")
+
+
+# --- first_meaningful_line：COMMIT_EDITMSG 會夾註解 -----------------------
+
+expect(
+    first_meaningful_line("fix: 正常 (#1)\n\n# 註解\n") == "fix: 正常 (#1)",
+    "第一行就是 subject 時取值錯誤",
+)
+expect(
+    first_meaningful_line("# 註解在前\n\nfix: 正常 (#1)\n") == "fix: 正常 (#1)",
+    "註解在前時應跳過註解取到 subject",
+)
+expect(first_meaningful_line("# 全是註解\n#\n") == "", "全註解應回空字串")
+
+
+# --- classify：版號等級 ---------------------------------------------------
+
+expect(classify([])[0] is None, "空 range 應該不升版（release commit 之後的情況）")
+expect(classify([c("feat: 新功能")])[0] == "minor", "feat 應升 minor")
+expect(classify([c("fix: 修正")])[0] == "patch", "fix 應升 patch")
+expect(classify([c("refactor: 重整")])[0] == "patch", "refactor 應升 patch")
+expect(classify([c("chore: 雜務")])[0] is None, "chore 不該升版")
+
+# BREAKING 蓋過一切，連不升版的 type 也一樣
+expect(classify([c("docs!: 破壞相容")])[0] == "major", "`!` 應升 major")
+expect(
+    classify([c("chore: 雜務", "BREAKING CHANGE: 設定格式變了")])[0] == "major",
+    "BREAKING CHANGE footer 應升 major",
+)
+
+# footer 會續行，且要在下一個空行處收住、不能吃到後面的段落
+_, _, breaking = classify(
+    [c("feat: 換設定格式", "BREAKING CHANGE: 舊的\n設定檔要重寫\n\n之後的段落")]
+)
+expect(
+    [text for _, text in breaking] == ["舊的 設定檔要重寫"],
+    f"BREAKING footer 續行未收成一行或吃過頭：{[t for _, t in breaking]}",
+)
+
+# 取最高等級，不是最後一個
+expect(
+    classify([c("fix: 修正"), c("feat: 新功能"), c("chore: 雜務")])[0] == "minor",
+    "混合時應取最高等級",
+)
+
+# 格式不合的 commit 只警告不中止，其餘照常計算。這裡是唯一會觸發 warn()
+# 的案例，把 stderr 收掉——不然測試通過時也印一行 `warning:`，看起來像失敗。
+with contextlib.redirect_stderr(io.StringIO()):
+    bump, sections, _ = classify([c("隨手改一下"), c("fix: 修正")])
+expect(bump == "patch", "格式不合的 commit 不該影響其他 commit 的版號計算")
+logged = [commit.subject for commit, _ in sections["Bug Fixes"]]
+expect(logged == ["fix: 修正"], f"格式不合的 commit 不該進 CHANGELOG：{logged}")
+
+
+# --- build_changelog_block：CHANGELOG 與 GitHub Release 內文的長相 --------
+
+_, sections, _ = classify([c("feat: 新功能"), c("fix: 修正")])
+block = build_changelog_block("o/r", "1.0.0", "1.1.0", sections, [], {}, "2026-08-12")
+expect(
+    block.index("### Features") < block.index("### Bug Fixes"),
+    "CHANGELOG 區塊順序應跟著 TYPE_TABLE 的宣告順序",
+)
+expect("* 新功能 ([0000000]" in block, "沒有 PR 編號時應退回 commit 連結")
+expect("## [1.1.0]" in block and "(2026-08-12)" in block, "版本標題或日期缺漏")
+
+
+# --- bump_version ---------------------------------------------------------
+
+expect(bump_version("2.7.2", "patch") == "2.7.3", "patch 進位錯誤")
+expect(bump_version("2.7.2", "minor") == "2.8.0", "minor 進位應歸零 patch")
+expect(bump_version("2.7.2", "major") == "3.0.0", "major 進位應歸零 minor/patch")
+
+
+# --- 表本身的自洽 ---------------------------------------------------------
+
+expect(
+    all(level in BUMP_RANK for _, level in TYPE_TABLE.values()),
+    "TYPE_TABLE 有 BUMP_RANK 不認得的等級（例如把 patch 打成 Patch）",
+)
+
+
+if failures:
+    print(f"FAILED（{len(failures)} 項）：", file=sys.stderr)
+    for f in failures:
+        print(f"  - {f}", file=sys.stderr)
+    raise SystemExit(1)
+
+print("OK")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,16 @@ jobs:
         run: |
           MSRV=$(grep '^rust-version' Cargo.toml | cut -d '"' -f 2)
           echo "msrv=$MSRV" >> $GITHUB_OUTPUT
+
+  # 發版腳本的邏輯（版號等級、subject 格式）決定了 tag 出不出得來，跟
+  # Rust 那邊無關，所以獨立成一個 job，不用等 toolchain 裝完。
+  release-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test release script
+        run: python3 .github/scripts/test_prepare_release.py
+
   lint:
     needs: prepare
     strategy:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,25 @@
+name: PR Title
+
+# squash merge 時，PR 有多個 commit 的話 subject 取自 PR 標題（repo 的
+# `squash_merge_commit_title` 是 `COMMIT_OR_PR_TITLE`），而那個 subject 決定
+# 版號。lefthook 的 commit-msg hook 只看得到本機 commit，看不到 PR 標題——
+# 這條 workflow 就是補那個缺口，讓格式錯誤死在 merge 之前（改標題一秒的事），
+# 而不是落到 main 上才發現漏發版。
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check PR title
+        env:
+          # 經環境變數傳入，不要直接內插進 shell —— 標題是使用者可控字串。
+          TITLE: ${{ github.event.pull_request.title }}
+        run: python3 .github/scripts/check_subject.py --text "$TITLE"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,66 @@ commit 圖是用一般文字繪製的，沒有終端協議需要支援。顯示�
 - 較複雜或會改變行為的修改，強烈建議先開 issue 討論做法，避免白做工。
 - 不要夾帶與該 pull request 主題無關的修改。
 
+### Commit 訊息
+
+採用 [Conventional Commits](https://www.conventionalcommits.org/)，格式是 `type: 描述`，
+描述用正體中文，尾端帶 issue 與 PR 編號（PR 那組由 squash merge 自動附上）：
+
+```text
+fix: gh CLI 呼叫加 timeout，並優化 GitHub 資料載入效率 (#57) (#58)
+```
+
+版號由 [.github/scripts/prepare_release.py](.github/scripts/prepare_release.py) 從
+merge 進 `main` 的 commit type 推算。判準是**這個 commit 有沒有改到使用者下載的執行檔**：
+
+| type | 版號 | CHANGELOG 區塊 |
+| --- | --- | --- |
+| `feat` | minor | Features |
+| `fix` | patch | Bug Fixes |
+| `perf` | patch | Performance |
+| `refactor` | patch | Refactors |
+| `revert` | patch | Reverts |
+| `build` | patch | Build System |
+| `style` | patch | Styles |
+| `docs` | 不動 | Documentation |
+| `test` | 不動 | Tests |
+| `ci` | 不動 | CI |
+| `chore` | 不動 | Chores |
+
+標記 `!`（例如 `feat!:`）或在 body 寫 `BREAKING CHANGE:` footer 一律升 major，
+不分 type。
+
+「不動」的 type 仍會列進 CHANGELOG，只是自己不觸發發版；跟其他有升版的 commit
+一起 merge 時會一併寫進該次版本。
+
+格式檢查有兩道，都在 merge 之前——落到 `main` 上才發現就只能改寫已推送的歷史了：
+
+- **本機 commit**：[lefthook](https://lefthook.dev/) 的 `commit-msg` hook。
+  先裝 lefthook（`brew install lefthook` 等），再在 repo 根目錄跑一次：
+
+  ```sh
+  lefthook install
+  ```
+
+  `git revert` / `git commit --fixup` / merge 這些 git 自己產生的訊息會放行，
+  不用為了它們加 `--no-verify`。但要注意 `Revert "…"` 這種預設標題**不會升版號**
+  ——要發版請把 subject 改成 `revert: 描述 (#issue)`。
+
+- **PR 標題**：[pr-title.yml](.github/workflows/pr-title.yml)。squash merge 時，
+  PR 有多個 commit 的話 subject 取自 PR 標題而不是 commit 訊息，本機 hook 看不到，
+  所以這道獨立檢查不能少。
+
+`main` 上的 release workflow 不會因為格式不合而中止，只留 warning annotation；
+「這次 push 沒有升版號」同樣只留 warning。**CI 綠燈不等於有發版**，看 annotation。
+
+merge 前想自己確認會發出什麼版本：
+
+```sh
+python3 .github/scripts/prepare_release.py --from "$(git describe --tags --abbrev=0)" --dry-run
+```
+
+`pre-push` hook 會自動跑這一行，只提示不擋推。
+
 ### 持續整合
 
 使用 [GitHub Actions](.github/workflows/build.yml) 執行基本檢查：

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,25 @@
+# 本機 git hooks。安裝：`lefthook install`（見 CONTRIBUTING.md）。
+#
+# 只做「快到不會讓人想跳過」的檢查。fmt／clippy／test 留給 CI 跑完整版——
+# 在 commit 階段跑編譯會讓每次 commit 等好幾秒，結果就是大家開始用
+# `--no-verify`，等於沒有 hook。
+
+commit-msg:
+  commands:
+    conventional-commit:
+      # {1} 是 git 傳進來的 COMMIT_EDITMSG 路徑，要加引號——worktree 情境下
+      # 那是絕對路徑，repo 路徑含空白時沒引號會被拆成兩個參數。
+      run: python3 .github/scripts/check_subject.py "{1}"
+
+pre-push:
+  commands:
+    # 推之前先預覽這批 commit 會發出什麼版本，順便讓「一個都不會升版號」
+    # 浮出來。只提示不擋推：NO_BUMP 本來就是合法結果，而預覽的是 branch
+    # 全部 commit，squash 後真正決定版號的是 PR 標題，兩者不一定相同。
+    #
+    # 只在「還沒有任何 tag」時安靜跳過（git describe 會失敗）；腳本自己
+    # 壞掉要讓它出聲，不然這個預覽壞了也沒人知道。
+    release-preview:
+      run: |
+        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null) || exit 0
+        python3 .github/scripts/prepare_release.py --from "$LAST_TAG" --dry-run


### PR DESCRIPTION
## 起因

PR #64 squash-merge 進 `main` 時 subject 是 `refactor: …`，而 `TYPE_TABLE` 裡 `refactor` 的 bump 等級是 `None`，腳本印 `NO_BUMP` 直接 return——沒發版、沒 tag、沒跨平台產物，而且 workflow 全綠。更早一次連 conventional 前綴都沒有，同樣靜默略過。

漏發版跟正常發版在 run 頁面上長得一模一樣，這才是根因。

## 改動

**1. 版號對照表補齊 11 種 type**

判準是「這個 commit 有沒有改到使用者下載的執行檔」：

| 版號 | type |
| --- | --- |
| major | 任何帶 `!` 或 `BREAKING CHANGE:` footer 的 |
| minor | `feat` |
| patch | `fix` `perf` `refactor` `revert` `build` `style` |
| 不動 | `docs` `test` `ci` `chore` |

原本只認 4 種，`chore`（歷史用 43 次）、`test`、`docs`、`style` 連 CHANGELOG 都進不去。

**2. 格式檢查前移到 merge 之前**

曾經寫成在 `main` 上硬擋，但 review 指出兩個問題：擋在那裡除了改寫已推送的歷史沒有別的解法；而且 `upstream`（`lusingander/serie`）最近 30 個 commit 有 29 個不符格式，下次同步會把整條發版線鎖死。改成兩道前置檢查：

- **lefthook** 的 `commit-msg` hook —— 管本機 commit
- **`pr-title.yml`** —— 管 PR 標題。repo 的 `squash_merge_commit_title` 是 `COMMIT_OR_PR_TITLE`，多 commit PR 的 squash 標題取自 PR 標題，本機 hook 看不到這條路徑，正是這次出錯的地方

兩者共用 `check_subject.py`，規範只有一份定義。`git revert` / `git commit --fixup` / merge 這些 git 自己產的訊息放行（用雙引號比對 `Revert "…"` / `Reapply "…"`，人手打的「Revert 掉某功能」仍會被擋）。

**3. `main` 上改成留 warning annotation**

格式不合一則、`NO_BUMP` 一則。後者直接對症根因——CI 綠燈不再等於有發版。`warn()` 一律走 stderr，保住「stdout 只有結構化輸出」，`--print-section > release-notes.md` 不會被污染。

**4. 補測試**

`test_prepare_release.py` 涵蓋純函式（格式判斷、版號等級、BREAKING footer 續行、CHANGELOG 區塊生成），接進 `build.yml` 獨立 job，不用等 Rust toolchain。

## 驗證

- `python3 .github/scripts/test_prepare_release.py` 全過（本機與 `GITHUB_ACTIONS=true` 都無雜訊輸出）
- 對 `v2.7.2` 起算 dry-run → `bump=patch` / `version=2.7.3`，CHANGELOG 含 Refactors 與 CI 兩個區塊
- commit-msg hook 實測：合規通過、無前綴擋下、`chroe:` 打字錯誤擋下、`Revert "…"` 放行、`Revert 掉自動更新功能` 擋下
- 這個 PR 自己的 commit 就是經 hook 檢查過的

merge 後會補發 **v2.7.3**，把 #64 那次漏掉的發版一起帶出來。