### PR TITLE
feat: gh detail commit 集中成一區，簡化分隔線邏輯 (#71)

### DIFF
--- a/src/view/github/event.rs
+++ b/src/view/github/event.rs
@@ -138,6 +138,9 @@ impl<'a> GitHubView<'a> {
             UserEvent::ToggleCommitLog if matches!(self.active_tab, GitHubTab::PullRequests) => {
                 self.toggle_commit_log();
             }
+            UserEvent::Refresh => {
+                self.dispatch_refresh();
+            }
             _ => {}
         }
     }
@@ -225,17 +228,11 @@ impl<'a> GitHubView<'a> {
                 self.selected_index = 0;
                 self.offset = 0;
                 self.preview_offset = 0;
-                self.load_state = LoadState::Loading;
                 self.bump_generation();
-                self.tx.send(AppEvent::RefreshGitHub {
-                    state: self.state_filter,
-                });
+                self.dispatch_refresh();
             }
             UserEvent::Refresh => {
-                self.load_state = LoadState::Loading;
-                self.tx.send(AppEvent::RefreshGitHub {
-                    state: self.state_filter,
-                });
+                self.dispatch_refresh();
             }
             UserEvent::ShortCopy => {
                 let kind = self.active_tab.kind();
@@ -272,6 +269,15 @@ impl<'a> GitHubView<'a> {
             }
             _ => {}
         }
+    }
+
+    /// 重抓整份 GitHub 資料；資料沒變時 `update_data` 的 early-return
+    /// 分支會順帶重抓選取項目的 timeline。
+    fn dispatch_refresh(&mut self) {
+        self.load_state = LoadState::Loading;
+        self.tx.send(AppEvent::RefreshGitHub {
+            state: self.state_filter,
+        });
     }
 
     fn try_merge_selected_pr(&mut self) {

--- a/src/view/github/mod.rs
+++ b/src/view/github/mod.rs
@@ -453,7 +453,16 @@ impl<'a> GitHubView<'a> {
         after: Option<String>,
         page: GhTimelinePage,
     ) {
+        // commit block 畫在 timeline 最前面（見 `timeline::build_timeline`），
+        // 所以「載入更多」把新 commit 插進正在檢視的項目時，等於在使用者
+        // 視窗上方塞進新內容。只補償這個情況——首頁替換／背景刷新不移動
+        // 既有內容的相對位置，`preview_offset` 不用動。
+        let track_scroll =
+            after.is_some() && self.selected_number_and_kind() == Some((number, kind));
+
         let entry = self.timeline.entry((kind, number)).or_default();
+        let before_height =
+            track_scroll.then(|| timeline::commit_block_height(&entry.items, self.expand_commits));
         if after.is_none() {
             entry.items.clear();
         }
@@ -464,6 +473,13 @@ impl<'a> GitHubView<'a> {
         entry.loading_more = false;
         entry.refreshing = false;
         entry.rev = entry.rev.wrapping_add(1);
+
+        if let Some(before_height) = before_height {
+            let after_height = timeline::commit_block_height(&entry.items, self.expand_commits);
+            self.preview_offset = self
+                .preview_offset
+                .saturating_add(after_height.saturating_sub(before_height));
+        }
     }
 
     pub fn set_timeline_error(&mut self, number: u64, kind: GhItemKind, error: String) {
@@ -1287,6 +1303,71 @@ mod tests {
         assert_eq!(entry.rev, 3);
     }
 
+    /// commit block 畫在 timeline 最前面。載入更多把新 commit 插進正在
+    /// 檢視的項目時，等於在使用者視窗上方塞進新內容——`preview_offset`
+    /// 必須跟著位移，畫面才不會因為視窗上方多出內容而往回跳。
+    #[test]
+    fn loading_more_commits_shifts_preview_offset_to_keep_scroll_position() {
+        let mut view = view_with_body("body".to_string());
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(
+                vec![timeline_comment("a", "one")],
+                Some("cursor".to_string()),
+            ),
+        );
+
+        view.preview_offset = 5;
+
+        // 續接第二頁，這頁帶了兩個新 commit——commit block 從無到有，
+        // 佔掉 1 條分隔線 + 2 行 commit（展開模式）。
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            Some("cursor".to_string()),
+            timeline_page(
+                vec![
+                    timeline_commit("aaaaaaa", "SUCCESS"),
+                    timeline_commit("bbbbbbb", "SUCCESS"),
+                ],
+                None,
+            ),
+        );
+
+        assert_eq!(view.preview_offset, 5 + 3);
+    }
+
+    /// 首頁替換（`after: None`，刷新或切換選取）不移動既有內容的相對
+    /// 位置，`preview_offset` 不該被這個補償邏輯動到。
+    #[test]
+    fn refreshing_first_page_does_not_shift_preview_offset() {
+        let mut view = view_with_body("body".to_string());
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(vec![timeline_comment("a", "one")], None),
+        );
+        view.preview_offset = 5;
+
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(
+                vec![
+                    timeline_commit("aaaaaaa", "SUCCESS"),
+                    timeline_comment("a", "one"),
+                ],
+                None,
+            ),
+        );
+
+        assert_eq!(view.preview_offset, 5);
+    }
+
     /// `item_count`／`mergeable` 都沒變，只有 CI 狀態換了——沒有 `rev`
     /// 欄位，`PreviewKey` 會判定「跟上次一樣」，直接命中舊 cache，畫面
     /// 紋風不動。這裡刻意走 `render_to_string`（進到
@@ -1386,8 +1467,9 @@ mod tests {
             timeline_page(
                 vec![
                     timeline_commit("aaaaaaa", "SUCCESS"),
-                    timeline_comment("a", "one"),
                     timeline_commit("bbbbbbb", "SUCCESS"),
+                    timeline_comment("a", "one"),
+                    timeline_comment("b", "two"),
                 ],
                 None,
             ),
@@ -1411,14 +1493,80 @@ mod tests {
             vec![
                 // meta → body：markdown 自己的灰色，維持不變
                 ('─', Some(Color::DarkGray)),
-                // body → 第一個 commit
+                // body → commit block（兩個 commit 集中在一起）
                 ('─', Some(Section::Body.color())),
-                // commit → comment
+                // commit block → 第一則留言
                 ('─', Some(Section::Commit.color())),
-                // comment → commit
+                // 第一則留言 → 第二則留言
                 ('─', Some(Section::Comment.color())),
             ],
         );
+    }
+
+    /// commit 集中成一個區塊：即使 API 回傳的時間序是 commit/comment 交錯，
+    /// 展開模式下所有 commit 仍緊貼著彼此排在第一則留言之前，中間沒有
+    /// 分隔線把它們切開。
+    #[test]
+    fn commits_are_grouped_together_before_the_first_comment() {
+        let mut view = view_with_body("body".to_string());
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(
+                vec![
+                    timeline_commit("aaaaaaa", "SUCCESS"),
+                    timeline_comment("a", "one"),
+                    timeline_commit("bbbbbbb", "SUCCESS"),
+                    timeline_commit("ccccccc", "SUCCESS"),
+                ],
+                None,
+            ),
+        );
+
+        let (lines, _) = build_preview_content(&view.preview_input(40));
+        let texts: Vec<String> = lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.to_string()).collect())
+            .collect();
+
+        let commit_positions: Vec<usize> = texts
+            .iter()
+            .enumerate()
+            .filter(|(_, t)| {
+                t.contains("aaaaaaa") || t.contains("bbbbbbb") || t.contains("ccccccc")
+            })
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(commit_positions.len(), 3, "got: {texts:?}");
+        // 三個 commit 緊貼彼此：中間沒有其他列（分隔線或留言）插進來。
+        assert!(
+            commit_positions.windows(2).all(|w| w[1] == w[0] + 1),
+            "commits must be contiguous, got: {texts:?}"
+        );
+
+        let comment_index = texts.iter().position(|t| t.contains("one")).unwrap();
+        assert!(
+            commit_positions.iter().all(|&i| i < comment_index),
+            "all commits must come before the comment, got: {texts:?}"
+        );
+    }
+
+    /// 只有 commit、沒有留言的 PR 不該顯示「沒有留言」——那是專門為「整條
+    /// timeline 都沒有可渲染內容」保留的訊息。commit block 本身就是內容，
+    /// 而且 timelineItems 是混合 connection，留言完全有可能落在下一頁。
+    #[test]
+    fn commits_without_comments_do_not_show_no_comments_notice() {
+        let mut view = view_with_body("body".to_string());
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(vec![timeline_commit("aaaaaaa", "SUCCESS")], None),
+        );
+
+        let screen = render_to_string(&mut view);
+        assert!(!screen.contains("no comments"), "got:\n{screen}");
     }
 
     #[test]

--- a/src/view/github/mod.rs
+++ b/src/view/github/mod.rs
@@ -555,6 +555,7 @@ impl<'a> GitHubView<'a> {
                 if self.selected_has_related() {
                     hints.push(h(&[UserEvent::DetailPaneToggle], "related"));
                 }
+                hints.push(h(&[UserEvent::Refresh], "refresh"));
                 hints
             }
             GitHubFocus::List => {
@@ -1782,5 +1783,45 @@ mod tests {
 
         view.handle_list_event(UserEvent::ToggleCommitLog, 1);
         assert!(view.expand_commits);
+    }
+
+    /// `r` 在 List 跟 Preview 兩個 focus 都要能觸發同一個刷新動作——
+    /// Preview 之前完全沒有接 `UserEvent::Refresh`，在 gh 的 detail
+    /// （PR/Issue 詳情，含留言）裡按 r 沒有任何反應。
+    #[test]
+    fn refresh_triggers_from_both_list_and_preview_focus() {
+        let (mut view, rx) = view_with_body_and_rx("body".to_string());
+
+        view.handle_preview_event(UserEvent::Refresh, 1);
+        assert!(matches!(view.load_state, LoadState::Loading));
+        let sent = rx.try_recv();
+        assert!(
+            matches!(sent, Ok(AppEvent::RefreshGitHub { .. })),
+            "preview focus must send RefreshGitHub, got: {sent:?}"
+        );
+
+        view.load_state = LoadState::Idle;
+        view.handle_list_event(UserEvent::Refresh, 1);
+        assert!(matches!(view.load_state, LoadState::Loading));
+        let sent = rx.try_recv();
+        assert!(
+            matches!(sent, Ok(AppEvent::RefreshGitHub { .. })),
+            "list focus must keep sending RefreshGitHub, got: {sent:?}"
+        );
+    }
+
+    /// Preview 的狀態列必須把 `refresh` 提示出來，使用者才知道 r 在這裡
+    /// 有作用，不用去猜或翻說明頁。
+    #[test]
+    fn preview_status_hints_include_refresh() {
+        let mut view = view_with_body("body".to_string());
+        view.focus = GitHubFocus::Preview;
+        assert!(
+            view.status_hints()
+                .iter()
+                .any(|(events, _)| events.contains(&UserEvent::Refresh)),
+            "got: {:?}",
+            view.status_hints()
+        );
     }
 }

--- a/src/view/github/preview.rs
+++ b/src/view/github/preview.rs
@@ -106,11 +106,12 @@ pub(super) fn append_comment_lines(
     width: usize,
 ) {
     let mut prev = Section::Body;
-    for item in build_timeline(entry, expand_commits) {
-        let section = item.section();
+    for block in build_timeline(entry, expand_commits) {
         lines.push(prev.divider(width));
-        item.render(lines, width);
-        prev = section;
+        for item in block.items {
+            item.render(lines, width);
+        }
+        prev = block.section;
     }
 }
 

--- a/src/view/github/timeline.rs
+++ b/src/view/github/timeline.rs
@@ -36,8 +36,17 @@ pub(super) struct TimelineEntry {
     pub(super) rev: u64,
 }
 
+/// timeline 攤平後的一個可渲染區塊：同一個 section 底下連續出現的
+/// item（一整組 commit、單一則留言、或單一則狀態提示）。分隔線只畫在
+/// block 與 block 之間，所以同一個 commit block 裡的每一筆 commit 都
+/// 緊貼著彼此，不會像逐 item 判斷時那樣被切成一條一條。
+pub(super) struct TimelineBlock<'a> {
+    pub(super) section: Section,
+    pub(super) items: Vec<TimelineItem<'a>>,
+}
+
 /// 把 `TimelineEntry` 可能處於的每種狀態——pending、failed、loaded（空或
-/// 非空）、分頁中——攤平成一份可渲染列的清單。走訪結果的渲染迴圈本身
+/// 非空）、分頁中——攤平成一份可渲染 block 的清單。走訪結果的渲染迴圈本身
 /// 沒有任何分支：「我現在是什麼狀態」這個問題只在這裡回答一次。
 ///
 /// 回傳借用的項目而非 owned 複本，所以 `None`/`NotRequested` 這種
@@ -46,60 +55,89 @@ pub(super) struct TimelineEntry {
 pub(super) fn build_timeline(
     entry: Option<&TimelineEntry>,
     expand_commits: bool,
-) -> Vec<TimelineItem<'_>> {
+) -> Vec<TimelineBlock<'_>> {
     let Some(entry) = entry else {
-        return vec![TimelineItem::notice("(loading comments…)", Color::DarkGray)];
+        return vec![notice_block("(loading comments…)", Color::DarkGray)];
     };
 
     match &entry.state {
         TimelineLoad::NotRequested | TimelineLoad::Loading => {
-            vec![TimelineItem::notice("(loading comments…)", Color::DarkGray)]
+            vec![notice_block("(loading comments…)", Color::DarkGray)]
         }
-        TimelineLoad::Error(e) => vec![TimelineItem::notice(
-            format!("(comments failed: {e})"),
-            Color::Red,
-        )],
+        TimelineLoad::Error(e) => {
+            vec![notice_block(format!("(comments failed: {e})"), Color::Red)]
+        }
         TimelineLoad::Loaded => {
-            let mut items: Vec<TimelineItem<'_>> = entry
+            let (commits, comments): (Vec<_>, Vec<_>) = entry
                 .items
                 .iter()
                 .filter_map(TimelineItem::from_gh)
-                .collect();
-            if !expand_commits {
-                items = collapse_commits(items);
+                .partition(|item| matches!(item, TimelineItem::Commit { .. }));
+
+            let mut blocks = Vec::new();
+            if !commits.is_empty() {
+                let items = if expand_commits {
+                    commits
+                } else {
+                    vec![TimelineItem::CollapsedCommits(commits.len())]
+                };
+                blocks.push(TimelineBlock {
+                    section: Section::Commit,
+                    items,
+                });
             }
-            // 判斷用的是*過濾/收合後*的清單，不是 `entry.items`：一頁全是
-            // `Unknown` 節點時，仍然要 fallback 到提示訊息，而不是渲染出
-            // 零列（也就沒有任何分隔線）——而且收合絕不會把非空清單變空。
-            if items.is_empty() {
-                items.push(TimelineItem::notice("(no comments)", Color::DarkGray));
+            blocks.extend(comments.into_iter().map(|item| TimelineBlock {
+                section: Section::Comment,
+                items: vec![item],
+            }));
+
+            // 判斷用的是*過濾/分組後*的 block 清單，不是 `entry.items`：一頁
+            // 全是 `Unknown` 節點時，仍然要 fallback 到提示訊息，而不是渲染
+            // 出零列（也就沒有任何分隔線）。判空主體刻意維持整條 timeline，
+            // 不是只看 comments——`timelineItems` 是一條混合 connection，
+            // 前 100 筆全是 commit、留言落在下一頁的長命 PR 很常見，只看
+            // comments 會在那種情況印出騙人的「沒有留言」。
+            if blocks.is_empty() {
+                blocks.push(notice_block("(no comments)", Color::DarkGray));
             } else if entry.next_cursor.is_some() {
                 let text = if entry.loading_more {
                     "(loading more…)"
                 } else {
                     "(more comments — scroll down to load)"
                 };
-                items.push(TimelineItem::notice(text, Color::DarkGray));
+                // `next_cursor` 代表「還有 timelineItems」，不是「還有留言」
+                // ——文案沿用舊字樣，即使下一頁其實是更多 commit 也一樣，
+                // 避免為了措辭精確而長出第二種 footer。
+                blocks.push(notice_block(text, Color::DarkGray));
             }
-            items
+            blocks
         }
     }
 }
 
-/// 把每一筆獨立的 `Commit` 列取代成一行摘要，放在 timeline 最前面、留言
-/// 之前——對應網頁版 UI 的「N commits」收合檢視，而不是在每個 commit
-/// 原本所在的位置留下空隙。
-fn collapse_commits(mut items: Vec<TimelineItem<'_>>) -> Vec<TimelineItem<'_>> {
-    let mut commit_count = 0;
-    items.retain(|item| {
-        let is_commit = matches!(item, TimelineItem::Commit { .. });
-        commit_count += usize::from(is_commit);
-        !is_commit
-    });
-    if commit_count > 0 {
-        items.insert(0, TimelineItem::CollapsedCommits(commit_count));
+fn notice_block(text: impl Into<String>, color: Color) -> TimelineBlock<'static> {
+    TimelineBlock {
+        section: Section::Comment,
+        items: vec![TimelineItem::notice(text, color)],
     }
-    items
+}
+
+/// commit block 在 timeline 裡佔的視覺行數：沒有 commit 就是 0（不畫這個
+/// block，也不畫它前面那條分隔線）；否則是 1 條分隔線，加上展開時每個
+/// commit 各一行、收合時固定一行的收合摘要。`append_timeline_items` 用
+/// 它算分頁載入前後的差值來補償 `preview_offset`——commit block 插在
+/// timeline 最前面，插入的視覺行數必須讓捲動位置跟著往下位移，畫面才不會
+/// 因為視窗上方多出內容而往回跳。
+pub(super) fn commit_block_height(items: &[GhTimelineItem], expand_commits: bool) -> usize {
+    let count = items
+        .iter()
+        .filter(|item| matches!(item, GhTimelineItem::PullRequestCommit { .. }))
+        .count();
+    match (count, expand_commits) {
+        (0, _) => 0,
+        (n, true) => 1 + n,
+        (_, false) => 2,
+    }
 }
 
 /// timeline 的一列可渲染內容：留言、commit、收合後的 commit 數量摘要，
@@ -149,13 +187,6 @@ impl<'a> TimelineItem<'a> {
                     .map(|r| r.state.as_str()),
             }),
             GhTimelineItem::Unknown => None,
-        }
-    }
-
-    pub(super) fn section(&self) -> Section {
-        match self {
-            TimelineItem::Comment { .. } | TimelineItem::Notice(_) => Section::Comment,
-            TimelineItem::Commit { .. } | TimelineItem::CollapsedCommits(_) => Section::Commit,
         }
     }
 


### PR DESCRIPTION
## 變更摘要

- timeline 不再照 API 時間序交錯渲染 commit 與留言，改用 `TimelineBlock` 把 commit 收攏成一個區塊放在 body 之後、留言之前，展開與收合模式版面一致
- 分隔線迭代單位從逐 item 換成逐 block，簡化判斷邏輯
- 修掉分頁載入時 commit 插入畫面上方導致的 `preview_offset` 捲動跳位
- `UserEvent::Refresh`（`r`）原本只在 `GitHubFocus::List` 有接，`GitHubFocus::Preview`（PR/Issue 詳情頁，含留言 timeline）按 r 完全沒反應，一併修正並抽出共用的 `dispatch_refresh`

Closes #71

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --verbose` 通過（519 tests）