### PR TITLE
feat: 更新後首次啟動自動顯示 Release Notes (#73)

### DIFF
--- a/assets/default-config.toml
+++ b/assets/default-config.toml
@@ -16,10 +16,11 @@ initial_selection = "latest"  # 啟動時初始選取：latest｜head
 # max_count = 1000
 
 [core.update]
-# 自動更新設定，對應 --update-mode/--update-interval/--auto-restart。
+# 自動更新設定，對應 --update-mode/--update-interval/--auto-restart/--release-notes。
 mode = "check"          # off（完全不自動檢查）｜check（查到問 y/n）｜auto（查到直接裝）
 interval_hours = 6      # 檢查間隔（小時），範圍 1-48；啟動查一次，之後持續運作期間每隔這個時間再查
 auto_restart = "off"    # off｜on——on 的話更新完不再詢問，TUI 直接重啟、CLI（-U）直接開啟
+release_notes = "on"    # off｜on——版本變了第一次啟動要不要自動跳出 release notes；--whats-new 隨時可手動查看
 
 [core.search]
 ignore_case = false  # 是否預設忽略大小寫

--- a/config.schema.json
+++ b/config.schema.json
@@ -96,6 +96,15 @@
                 "on"
               ],
               "default": "off"
+            },
+            "release_notes": {
+              "type": "string",
+              "description": "Whether to automatically show this version's release notes the first time it's launched after an update (or a fresh install). Reads the embedded CHANGELOG.md, no network involved. The value specified in the command line argument takes precedence.",
+              "enum": [
+                "off",
+                "on"
+              ],
+              "default": "on"
             }
           },
           "additionalProperties": false

--- a/docs/src/configurations/config-file-format.md
+++ b/docs/src/configurations/config-file-format.md
@@ -14,6 +14,7 @@ initial_selection = "latest"
 mode = "check"
 interval_hours = 6
 auto_restart = "off"
+release_notes = "on"
 
 [core.search]
 ignore_case = false
@@ -210,6 +211,20 @@ Commit 圖形的邊線風格。
 
 - 型別：`string`（enum）
 - 預設值：`off`
+- 可選值：
+  - `off`
+  - `on`
+
+命令列參數指定的值優先。
+
+### `core.update.release_notes`
+
+版本變了（或全新安裝）、第一次啟動時是否自動跳出該版的 release notes。
+內容取自內嵌的 `CHANGELOG.md`，不連網、不受 `YSGIT_NO_UPDATE_CHECK`
+影響。`--whats-new` 可以隨時手動查看目前版本的內容，不受這個設定限制。
+
+- 型別：`string`（enum）
+- 預設值：`on`
 - 可選值：
   - `off`
   - `on`

--- a/docs/src/getting-started/command-line-options.md
+++ b/docs/src/getting-started/command-line-options.md
@@ -186,6 +186,27 @@ _可選值：_ `off`、`on`
 
 設定檔對應鍵是 `core.update.auto_restart`，命令列參數指定的值優先。
 
+## --release-notes \<TYPE\>
+
+版本變了（或全新安裝）、第一次啟動時是否自動跳出該版的 release notes。
+
+_可選值：_ `off`、`on`
+
+內容取自內嵌的 `CHANGELOG.md`，不連網、不受 `YSGIT_NO_UPDATE_CHECK` 影響。
+想略過這個設定隨時手動查看，見下方 [`--whats-new`](#--whats-new)。
+
+設定檔對應鍵是 `core.update.release_notes`，命令列參數指定的值優先。
+
+## --whats-new
+
+顯示目前這一版的 release notes 並離開，不進 TUI，不受 `--release-notes` 開關
+限制。內容取自內嵌的 `CHANGELOG.md`，可以 pipe 給 `less` 之類的工具閱讀。
+
+```sh
+ysgit --whats-new
+ysgit --whats-new | less
+```
+
 ## -U, --update
 
 檢查 GitHub Release 是否有新版，有就下載對應這台機器的執行檔並就地替換。

--- a/docs/src/keybindings/index.md
+++ b/docs/src/keybindings/index.md
@@ -177,6 +177,19 @@
 | <kbd>Enter</kbd> <kbd>y</kbd> | 顯示 commit 詳情 | `confirm` |
 | <kbd>F1</kbd> <kbd>?</kbd> | 開啟說明 | `help_toggle` |
 
+### Release Notes
+
+| 按鍵 | 說明 | 設定鍵名 |
+| --- | --- | --- |
+| <kbd>q</kbd> | 離開（按兩下） | `quit` |
+| <kbd>n</kbd> <kbd>Esc</kbd> <kbd>Backspace</kbd> <kbd>Left</kbd> <kbd>h</kbd> | 關閉 release notes | `cancel` `close` `navigate_left` |
+| <kbd>Down</kbd> <kbd>j</kbd> <kbd>J</kbd> | 向下捲動 | `navigate_down` `select_down` |
+| <kbd>Up</kbd> <kbd>k</kbd> <kbd>K</kbd> | 向上捲動 | `navigate_up` `select_up` |
+| <kbd>PageDown</kbd> <kbd>Ctrl-f</kbd> | 向下一頁 | `page_down` |
+| <kbd>PageUp</kbd> <kbd>Ctrl-b</kbd> | 向上一頁 | `page_up` |
+| <kbd>Ctrl-d</kbd> | 向下半頁 | `half_page_down` |
+| <kbd>Ctrl-u</kbd> | 向上半頁 | `half_page_up` |
+
 ## 寫死的按鍵
 
 以下按鍵無法透過設定檔變更，因為它們屬於一次性的提示互動，不歸任何 view 的 keymap 管。

--- a/src/app.rs
+++ b/src/app.rs
@@ -399,6 +399,13 @@ impl App<'_> {
                 AppEvent::CloseGitHub => {
                     self.close_github();
                 }
+                AppEvent::OpenReleaseNotes { body } => {
+                    self.open_release_notes(body);
+                }
+                AppEvent::CloseReleaseNotes => {
+                    terminal.clear()?;
+                    self.close_release_notes();
+                }
                 AppEvent::RefreshGitHub { state } => {
                     self.refresh_github(state);
                 }
@@ -1210,6 +1217,24 @@ impl App<'_> {
 
     fn close_help(&mut self) {
         if let View::Help(ref mut view) = self.view {
+            self.view = view.take_before_view();
+            self.view.request_graph_clear();
+        }
+    }
+
+    /// 這裡才是「看過」這一版 release notes 的認定時機——不是
+    /// `update::pending_release_notes()` 決定要跳的那一刻。view 真的建出
+    /// 來、下一幀就會畫出來，才算數；`lib.rs::run()` 決定完之後還有
+    /// `git::Repository::load(...)?` 這類會早退的路徑，早退的話畫面根本
+    /// 沒出現過，這一版的 notes 不該被記成已看過。
+    fn open_release_notes(&mut self, body: &'static str) {
+        crate::update::mark_version_seen();
+        let before_view = std::mem::take(&mut self.view);
+        self.view = View::of_release_notes(before_view, body, self.ctx.clone(), self.ec.sender());
+    }
+
+    fn close_release_notes(&mut self) {
+        if let View::ReleaseNotes(ref mut view) = self.view {
             self.view = view.take_before_view();
             self.view.request_graph_clear();
         }

--- a/src/app/status_line.rs
+++ b/src/app/status_line.rs
@@ -82,6 +82,12 @@ fn build_hotkey_hints(view: &View, ctx: &AppContext) -> Line<'static> {
             h(&[UserEvent::Close], "close"),
         ],
         View::GitHub(ref view) => view.status_hints(),
+        View::ReleaseNotes(_) => vec![
+            h(&[UserEvent::NavigateDown, UserEvent::NavigateUp], "scroll"),
+            h(&[UserEvent::HalfPageDown], "half"),
+            h(&[UserEvent::PageDown], "page"),
+            h(&[UserEvent::Close], "close"),
+        ],
         // 窮舉而非 `_`：新增一個 view 時要在這裡被編譯器叫住，
         // 而不是靜默得到一條空提示列。
         View::Default => vec![],

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ use umbra::optional;
 use crate::{
     color::{ColorTheme, OptionalColorTheme},
     keybind::KeyBind,
-    update::{AutoRestart, UpdateMode, MAX_INTERVAL_HOURS, MIN_INTERVAL_HOURS},
+    update::{AutoRestart, ReleaseNotes, UpdateMode, MAX_INTERVAL_HOURS, MIN_INTERVAL_HOURS},
     CommitOrderType, CompactType, GraphStyle, GraphWidthType, InitialSelection, Result,
 };
 
@@ -178,11 +178,11 @@ pub struct CoreOptionConfig {
     pub max_count: Option<usize>,
 }
 
-/// 自動更新設定，三個欄位對應 `-U`／背景檢查／重啟提示。`interval_hours`
-/// 要驗證範圍：設 0 會讓週期檢查退化成無限打網路，沒有上限則
-/// `hours * 3600` 在 release build 會 wrapping、繞回極小值，回到同一個熱
-/// 迴圈——兩者都要在載入時就擋掉，不能靠程式裡默默 clamp（那會讓使用者
-/// 以為設定生效了）。
+/// 自動更新設定，四個欄位對應 `-U`／背景檢查／重啟提示／更新後跳
+/// release notes。`interval_hours` 要驗證範圍：設 0 會讓週期檢查退化成
+/// 無限打網路，沒有上限則 `hours * 3600` 在 release build 會 wrapping、
+/// 繞回極小值，回到同一個熱迴圈——兩者都要在載入時就擋掉，不能靠程式裡
+/// 默默 clamp（那會讓使用者以為設定生效了）。
 #[optional(derives = [Deserialize])]
 #[derive(Debug, Clone, PartialEq, Eq, SmartDefault, Validate)]
 pub struct CoreUpdateConfig {
@@ -192,6 +192,8 @@ pub struct CoreUpdateConfig {
     pub interval_hours: Option<u64>,
     #[garde(skip)]
     pub auto_restart: Option<AutoRestart>,
+    #[garde(skip)]
+    pub release_notes: Option<ReleaseNotes>,
 }
 
 #[optional(derives = [Deserialize])]
@@ -709,6 +711,7 @@ mod tests {
                     mode: None,
                     interval_hours: None,
                     auto_restart: None,
+                    release_notes: None,
                 },
                 search: CoreSearchConfig {
                     ignore_case: false,
@@ -807,6 +810,7 @@ mod tests {
                     mode: None,
                     interval_hours: None,
                     auto_restart: None,
+                    release_notes: None,
                 },
                 search: CoreSearchConfig {
                     ignore_case: true,
@@ -1094,28 +1098,39 @@ mod tests {
         );
     }
 
-    /// `graph_width` 的可選值散在四個地方：`GraphWidthType` 的 derive、
-    /// `config.schema.json` 的 enum、還有兩份文件的清單。上面那個測試只比
-    /// 「鍵」有沒有宣告，值漂移它一律放行 —— 可選值增減時這道檢查是唯一
+    /// enum 型欄位的可選值散在四個地方：`ValueEnum` 的 derive、
+    /// `config.schema.json` 的 enum、還有兩份文件的清單。「鍵有沒有宣告」
+    /// 已經有別的測試比對，值漂移它一律放行——可選值增減時這道檢查是唯一
     /// 會響的。
     ///
     /// 比的是 clap 認得的全部字串（canonical 加別名），所以 schema 少列
     /// 別名、或留著已經拿掉的值，兩種方向都會被抓到。
-    #[test]
-    fn graph_width_schema_enum_matches_every_accepted_cli_value() {
-        use clap::ValueEnum;
-
+    ///
+    /// `field_path` 是從 `core` 底下開始數的 schema 路徑（例如
+    /// `["update", "auto_restart"]` 對應 `core.update.auto_restart`），
+    /// 每個 enum 型欄位各自呼叫一次，不重複寫五份幾乎逐字相同的比對。
+    fn assert_schema_enum_matches_every_accepted_cli_value<T: clap::ValueEnum>(
+        field_path: &[&str],
+    ) {
         let schema: serde_json::Value =
             serde_json::from_str(include_str!("../config.schema.json")).unwrap();
-        let mut declared: Vec<String> = schema["properties"]["core"]["properties"]["option"]
-            ["properties"]["graph_width"]["enum"]
+        let mut node = &schema["properties"]["core"];
+        for segment in field_path {
+            node = &node["properties"][*segment];
+        }
+        let mut declared: Vec<String> = node["enum"]
             .as_array()
-            .expect("config.schema.json 裡的 graph_width 沒有 enum")
+            .unwrap_or_else(|| {
+                panic!(
+                    "config.schema.json 裡的 core.{} 沒有 enum",
+                    field_path.join(".")
+                )
+            })
             .iter()
             .map(|v| v.as_str().expect("enum 值不是字串").to_string())
             .collect();
 
-        let mut accepted: Vec<String> = GraphWidthType::value_variants()
+        let mut accepted: Vec<String> = T::value_variants()
             .iter()
             .flat_map(|variant| {
                 variant
@@ -1129,100 +1144,41 @@ mod tests {
 
         declared.sort();
         accepted.sort();
-        assert_eq!(declared, accepted);
+        assert_eq!(declared, accepted, "core.{}", field_path.join("."));
+    }
+
+    #[test]
+    fn graph_width_schema_enum_matches_every_accepted_cli_value() {
+        assert_schema_enum_matches_every_accepted_cli_value::<GraphWidthType>(&[
+            "option",
+            "graph_width",
+        ]);
     }
 
     #[test]
     fn compact_schema_enum_matches_every_accepted_cli_value() {
-        use clap::ValueEnum;
-
-        let schema: serde_json::Value =
-            serde_json::from_str(include_str!("../config.schema.json")).unwrap();
-        let mut declared: Vec<String> = schema["properties"]["core"]["properties"]["option"]
-            ["properties"]["compact"]["enum"]
-            .as_array()
-            .expect("config.schema.json 裡的 compact 沒有 enum")
-            .iter()
-            .map(|v| v.as_str().expect("enum 值不是字串").to_string())
-            .collect();
-
-        let mut accepted: Vec<String> = CompactType::value_variants()
-            .iter()
-            .flat_map(|variant| {
-                variant
-                    .to_possible_value()
-                    .expect("每個變體都該有對應的命令列值")
-                    .get_name_and_aliases()
-                    .map(str::to_string)
-                    .collect::<Vec<_>>()
-            })
-            .collect();
-
-        declared.sort();
-        accepted.sort();
-        assert_eq!(declared, accepted);
+        assert_schema_enum_matches_every_accepted_cli_value::<CompactType>(&["option", "compact"]);
     }
 
     #[test]
     fn update_mode_schema_enum_matches_every_accepted_cli_value() {
-        use clap::ValueEnum;
-
-        let schema: serde_json::Value =
-            serde_json::from_str(include_str!("../config.schema.json")).unwrap();
-        let mut declared: Vec<String> = schema["properties"]["core"]["properties"]["update"]
-            ["properties"]["mode"]["enum"]
-            .as_array()
-            .expect("config.schema.json 裡的 core.update.mode 沒有 enum")
-            .iter()
-            .map(|v| v.as_str().expect("enum 值不是字串").to_string())
-            .collect();
-
-        let mut accepted: Vec<String> = UpdateMode::value_variants()
-            .iter()
-            .flat_map(|variant| {
-                variant
-                    .to_possible_value()
-                    .expect("每個變體都該有對應的命令列值")
-                    .get_name_and_aliases()
-                    .map(str::to_string)
-                    .collect::<Vec<_>>()
-            })
-            .collect();
-
-        declared.sort();
-        accepted.sort();
-        assert_eq!(declared, accepted);
+        assert_schema_enum_matches_every_accepted_cli_value::<UpdateMode>(&["update", "mode"]);
     }
 
     #[test]
     fn auto_restart_schema_enum_matches_every_accepted_cli_value() {
-        use clap::ValueEnum;
+        assert_schema_enum_matches_every_accepted_cli_value::<AutoRestart>(&[
+            "update",
+            "auto_restart",
+        ]);
+    }
 
-        let schema: serde_json::Value =
-            serde_json::from_str(include_str!("../config.schema.json")).unwrap();
-        let mut declared: Vec<String> = schema["properties"]["core"]["properties"]["update"]
-            ["properties"]["auto_restart"]["enum"]
-            .as_array()
-            .expect("config.schema.json 裡的 core.update.auto_restart 沒有 enum")
-            .iter()
-            .map(|v| v.as_str().expect("enum 值不是字串").to_string())
-            .collect();
-
-        let mut accepted: Vec<String> = AutoRestart::value_variants()
-            .iter()
-            .flat_map(|variant| {
-                variant
-                    .to_possible_value()
-                    .expect("每個變體都該有對應的命令列值")
-                    .get_name_and_aliases()
-                    .map(str::to_string)
-                    .collect::<Vec<_>>()
-            })
-            .collect();
-
-        declared.sort();
-        accepted.sort();
-        assert_eq!(declared, accepted);
+    #[test]
+    fn release_notes_schema_enum_matches_every_accepted_cli_value() {
+        assert_schema_enum_matches_every_accepted_cli_value::<ReleaseNotes>(&[
+            "update",
+            "release_notes",
+        ]);
     }
 
     #[test]
@@ -1302,6 +1258,7 @@ mod tests {
             mode: None,
             interval_hours: Some(0),
             auto_restart: None,
+            release_notes: None,
         };
         assert!(update.validate().is_err());
     }
@@ -1312,6 +1269,7 @@ mod tests {
             mode: None,
             interval_hours: Some(MAX_INTERVAL_HOURS + 1),
             auto_restart: None,
+            release_notes: None,
         };
         assert!(update.validate().is_err());
     }
@@ -1322,6 +1280,7 @@ mod tests {
             mode: None,
             interval_hours: Some(MIN_INTERVAL_HOURS),
             auto_restart: None,
+            release_notes: None,
         };
         assert!(update.validate().is_ok());
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -57,6 +57,13 @@ pub enum AppEvent {
     CloseHelp,
     OpenGitHub,
     CloseGitHub,
+    /// 更新後（或全新安裝）第一次啟動時該顯示的 release notes——見
+    /// `update::pending_release_notes`。`body` 是編譯期常數
+    /// （`include_str!` 讀 `CHANGELOG.md`），不必轉成 `String`。
+    OpenReleaseNotes {
+        body: &'static str,
+    },
+    CloseReleaseNotes,
     RefreshGitHub {
         state: crate::github::StateFilter,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ use clap::{CommandFactory, Parser, ValueEnum};
 use graph::Graph;
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
-use update::{AutoRestart, UpdateMode};
+use update::{AutoRestart, ReleaseNotes, UpdateMode};
 
 /// ysgit - Git Graph in Terminal
 #[derive(Parser)]
@@ -93,6 +93,10 @@ struct Args {
     #[arg(long, value_name = "TYPE")]
     auto_restart: Option<AutoRestart>,
 
+    /// 版本變了、第一次啟動時是否自動跳出該版的 release notes [default: on]
+    #[arg(long, value_name = "TYPE")]
+    release_notes: Option<ReleaseNotes>,
+
     /// 顯示說明
     #[arg(short = 'h', long, action = clap::ArgAction::Help)]
     help: Option<bool>,
@@ -104,6 +108,10 @@ struct Args {
     /// 檢查 GitHub Release 並更新執行檔本身
     #[arg(short = 'U', long)]
     update: bool,
+
+    /// 顯示目前這一版的 release notes 並離開，不進 TUI
+    #[arg(long)]
+    whats_new: bool,
 }
 
 impl Args {
@@ -133,9 +141,13 @@ impl Args {
             update_mode,
             update_interval,
             auto_restart,
+            release_notes,
             help: _,
             version: _,
             update: _,
+            // 一次性動作旗標：印完 release notes 就離開，跟 `-U` 同一類——
+            // 重啟不該再把使用者導回這個早退路徑。
+            whats_new: _,
         } = self;
 
         let mut argv = vec!["ysgit".to_string()];
@@ -154,6 +166,10 @@ impl Args {
             (
                 "--auto-restart",
                 auto_restart.as_ref().map(wizard::variant_name),
+            ),
+            (
+                "--release-notes",
+                release_notes.as_ref().map(wizard::variant_name),
             ),
         ] {
             if let Some(value) = value {
@@ -434,6 +450,17 @@ pub fn run() -> Result<()> {
         return run_self_update(&args);
     }
 
+    // 同樣不進 TUI、不用讀 config：純粹把目前這一版的 CHANGELOG 區塊印到
+    // stdout，可以 pipe 給 `less`。跟 `--release-notes <on|off>`（開關）
+    // 刻意用不同名字，避免打錯字互相踩到。
+    if args.whats_new {
+        match update::current_release_notes() {
+            Some(notes) => println!("{notes}"),
+            None => println!("這個版本沒有對應的 CHANGELOG 區塊。"),
+        }
+        return Ok(());
+    }
+
     let (core_config, ui_config, color_theme, keybind_patch) = config::load()?;
     let keybind = keybind::KeyBind::new(keybind_patch);
 
@@ -454,11 +481,13 @@ pub fn run() -> Result<()> {
             mode: args.update_mode,
             interval_hours: args.update_interval,
             auto_restart: args.auto_restart,
+            release_notes: args.release_notes,
         },
         update::UpdateOverrides {
             mode: core_config.update.mode,
             interval_hours: core_config.update.interval_hours,
             auto_restart: core_config.update.auto_restart,
+            release_notes: core_config.update.release_notes,
         },
     );
 
@@ -503,6 +532,12 @@ pub fn run() -> Result<()> {
     // 清掃上次啟動可能留下的自我更新殘檔——跟這次的 `mode` 無關（上次啟動
     // 沒關閉時留下的殘檔，不能因為這次關了就不清），背景執行不擋啟動。
     std::thread::spawn(update::cleanup_stale_temp_files);
+    // 同樣只在整個 process 生命週期跑一次——放進 `App::run()` 迴圈的話，
+    // `Ret::Refresh` 重建 `App` 時會重跳。決定完不代表「看過了」：真正的
+    // marker 寫入時機在 `app::open_release_notes()`，這裡只負責判斷。
+    if let Some(body) = update::pending_release_notes(update_settings) {
+        ec.sender().send(event::AppEvent::OpenReleaseNotes { body });
+    }
     let mut refresh_view_context = None;
     let mut terminal = None;
 
@@ -673,11 +708,13 @@ fn run_self_update(args: &Args) -> Result<()> {
             mode: args.update_mode,
             interval_hours: args.update_interval,
             auto_restart: args.auto_restart,
+            release_notes: args.release_notes,
         },
         update::UpdateOverrides {
             mode: core_update.mode,
             interval_hours: core_update.interval_hours,
             auto_restart: core_update.auto_restart,
+            release_notes: core_update.release_notes,
         },
     );
 
@@ -766,6 +803,8 @@ mod tests {
             "12",
             "--auto-restart",
             "on",
+            "--release-notes",
+            "off",
             "/some/repo",
         ])
         .unwrap();
@@ -782,6 +821,7 @@ mod tests {
         assert_eq!(reparsed.update_mode, args.update_mode);
         assert_eq!(reparsed.update_interval, args.update_interval);
         assert_eq!(reparsed.auto_restart, args.auto_restart);
+        assert_eq!(reparsed.release_notes, args.release_notes);
         assert_eq!(reparsed.path, args.path);
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -29,7 +29,15 @@ const CHECKSUMS_URL: &str = concat!(
     env!("CARGO_PKG_REPOSITORY"),
     "/releases/latest/download/checksum.txt"
 );
-const MARKER_FILE_NAME: &str = ".ysgit.update_check";
+const UPDATE_CHECK_MARKER_FILE_NAME: &str = ".ysgit.update_check";
+const SEEN_VERSION_MARKER_FILE_NAME: &str = ".ysgit.seen_version";
+
+/// release.yml 的 upload job 把 `CHANGELOG.md` 裡當次版本的區塊原封不動當
+/// GitHub Release 的 body（見 `prepare_release.py::extract_changelog_section`）。
+/// `prepare` job 先 commit CHANGELOG＋打 tag，`build` job 才 checkout 該 tag
+/// 編譯，所以編譯進這個 binary 的 CHANGELOG.md 必然已經含當前版本的區塊——
+/// 不必打 GitHub API 就能在本機重現同一份內容，離線也能顯示。
+const CHANGELOG: &str = include_str!("../CHANGELOG.md");
 
 /// 自動更新檢查模式。
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum, Deserialize)]
@@ -58,6 +66,15 @@ pub enum AutoRestart {
     On,
 }
 
+/// 版本變了、第一次啟動時是否自動跳出該版的 release notes。
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReleaseNotes {
+    Off,
+    #[default]
+    On,
+}
+
 /// 檢查間隔的合法範圍（小時）；CLI／設定檔／精靈三處都要用同一組數字。
 pub const MIN_INTERVAL_HOURS: u64 = 1;
 pub const MAX_INTERVAL_HOURS: u64 = 48;
@@ -66,11 +83,18 @@ pub const DEFAULT_INTERVAL_HOURS: u64 = 6;
 /// CLI 與設定檔合併後的自動更新設定，`run()`／`run_self_update` 只算一次、
 /// 之後所有地方（`AppContext`、`-U` 的兩個 confirm、背景檢查 thread）都吃
 /// 這個值，不各自再 `.or()` 一遍。
+///
+/// `release_notes` 嚴格說不是「更新檢查」的一部分（它甚至不連網），但跟
+/// `auto_restart` 一樣是「更新之後的行為」，歸在同一組設定裡自洽。代價是
+/// 這個欄位會跟著整個 `UpdateSettings` 被塞進 `AppContext.update` 給所有
+/// view 看得到，也會傳進從不讀它的 `spawn_check`——只有 `run()` 開頭
+/// `update::pending_release_notes()` 那一次讀它。
 #[derive(Debug, Clone, Copy)]
 pub struct UpdateSettings {
     pub mode: UpdateMode,
     pub interval: Duration,
     pub auto_restart: bool,
+    pub release_notes: bool,
 }
 
 impl Default for UpdateSettings {
@@ -83,26 +107,31 @@ impl Default for UpdateSettings {
             mode: UpdateMode::default(),
             interval: Duration::from_secs(DEFAULT_INTERVAL_HOURS * 3600),
             auto_restart: false,
+            release_notes: true,
         }
     }
 }
 
-/// `resolve()` 的一組來源（CLI 或設定檔）。三個欄位型別兩兩相同
-/// （`Option<UpdateMode>`、`Option<u64>`、`Option<AutoRestart>`），拆開寫
-/// 成 6 個位置參數時 CLI 側跟設定檔側寫反編譯器抓不到——包成同一個具名
-/// 型別、呼叫端用欄位名字建構，才擋得住這種手滑。
+/// `resolve()` 的一組來源（CLI 或設定檔）。四個欄位型別兩兩相同
+/// （`Option<UpdateMode>`、`Option<u64>`、`Option<AutoRestart>`、
+/// `Option<ReleaseNotes>`），拆開寫成位置參數時 CLI 側跟設定檔側寫反編譯器
+/// 抓不到——包成同一個具名型別、呼叫端用欄位名字建構，才擋得住這種手滑。
 #[derive(Debug, Clone, Copy, Default)]
 pub struct UpdateOverrides {
     pub mode: Option<UpdateMode>,
     pub interval_hours: Option<u64>,
     pub auto_restart: Option<AutoRestart>,
+    pub release_notes: Option<ReleaseNotes>,
 }
 
 /// 唯一的合併入口：CLI > 設定檔 > 內建預設。`YSGIT_NO_UPDATE_CHECK` 在這裡
 /// 壓成 `mode = Off`——原本散在 `should_check_on_startup` 裡的另一個閘門，
-/// 併過來後全程只剩 `mode` 一個判斷點。
+/// 併過來後全程只剩 `mode` 一個判斷點。這個 env var **不影響**
+/// `release_notes`：它管的是「不要背景連網」，release notes 完全讀本機
+/// 內嵌的 `CHANGELOG.md`、不連網，兩者是不同的閘門——要關 release notes
+/// 請用 `--release-notes off` 或設定檔。
 ///
-/// 收純值而非整個 `&Args`／`&CoreConfig`：不必為了讀三個欄位就讓這個模組
+/// 收純值而非整個 `&Args`／`&CoreConfig`：不必為了讀四個欄位就讓這個模組
 /// 認得 `Args` 的私有欄位，呼叫端（`lib.rs::run()`）在自己的模組裡解構
 /// 一次即可，這個函式本身也因此是純函式，好測。
 pub fn resolve(cli: UpdateOverrides, config: UpdateOverrides) -> UpdateSettings {
@@ -117,10 +146,16 @@ pub fn resolve(cli: UpdateOverrides, config: UpdateOverrides) -> UpdateSettings 
         .unwrap_or(DEFAULT_INTERVAL_HOURS);
     let auto_restart =
         cli.auto_restart.or(config.auto_restart).unwrap_or_default() == AutoRestart::On;
+    let release_notes = cli
+        .release_notes
+        .or(config.release_notes)
+        .unwrap_or_default()
+        == ReleaseNotes::On;
     UpdateSettings {
         mode,
         interval: Duration::from_secs(interval_hours * 3600),
         auto_restart,
+        release_notes,
     }
 }
 
@@ -404,27 +439,52 @@ impl Drop for UpdateGuard {
     }
 }
 
-// ── 節流：一個 0-byte 檔，只看 mtime ──
+// ── marker 檔共用路徑邏輯 ──
 //
 // 兩層路徑：優先跟著執行檔走（`exe_dir()`），寫不進去（例如裝在
 // `/usr/local/bin` 這種唯讀目錄）就退到系統暫存目錄。只保護「寫不寫得
-// 進去」，不處理多使用者共用暫存目錄可能撞名——marker 內容只有 mtime，
-// 撞名的後果最多是誤判節流時機，不是安全問題，犯不著為它另外做隔離。
+// 進去」，不處理多使用者共用暫存目錄可能撞名——`.ysgit.update_check` 撞名
+// 的後果最多是誤判節流時機，`.ysgit.seen_version` 撞名最多是誤判有沒有
+// 看過某一版，都不是安全問題，犯不著為它另外做隔離。
+//
+// 兩個 marker（節流用的 `.ysgit.update_check`、記版本用的
+// `.ysgit.seen_version`）共用同一套「試優先層、失敗退暫存層」的路徑邏輯，
+// 差別只在檔名跟內容，所以收成一組帶 `name` 參數的函式，不重複寫兩份。
 
-fn primary_marker_path() -> Option<PathBuf> {
-    exe_dir().map(|dir| dir.join(MARKER_FILE_NAME))
+fn primary_marker_path(name: &str) -> Option<PathBuf> {
+    exe_dir().map(|dir| dir.join(name))
 }
 
-fn fallback_marker_path() -> PathBuf {
-    env::temp_dir().join(MARKER_FILE_NAME)
+fn fallback_marker_path(name: &str) -> PathBuf {
+    env::temp_dir().join(name)
 }
 
-/// 讀取用：兩個位置誰有檔就用誰，優先層先看。都沒有就當作「從沒檢查過」。
-fn existing_marker_path() -> Option<PathBuf> {
-    primary_marker_path()
+/// 讀取用：兩個位置誰有檔就用誰，優先層先看。都沒有就當作「從沒寫過」。
+fn existing_marker_path(name: &str) -> Option<PathBuf> {
+    primary_marker_path(name)
         .filter(|p| p.exists())
-        .or_else(|| Some(fallback_marker_path()).filter(|p| p.exists()))
+        .or_else(|| Some(fallback_marker_path(name)).filter(|p| p.exists()))
 }
+
+/// 寫入用：先試優先層，寫失敗（唯讀目錄）才退到暫存目錄。`.ysgit.update_check`
+/// 只在意 mtime，內容留空；`.ysgit.seen_version` 內容是版本字串。
+fn write_marker(name: &str, content: &str) {
+    if let Some(primary) = primary_marker_path(name) {
+        if write_marker_file(&primary, content) {
+            return;
+        }
+    }
+    write_marker_file(&fallback_marker_path(name), content);
+}
+
+fn write_marker_file(path: &Path, content: &str) -> bool {
+    if let Some(dir) = path.parent() {
+        let _ = fs::create_dir_all(dir);
+    }
+    fs::write(path, content).is_ok()
+}
+
+// ── 節流：一個 0-byte 檔，只看 mtime ──
 
 /// 距上次檢查是否已經超過 `interval`——純函式，供啟動檢查與週期檢查共用
 /// 判斷。`YSGIT_NO_UPDATE_CHECK` 不在這裡判斷：那個閘門已經併進 `resolve()`
@@ -437,7 +497,7 @@ fn check_due(last_checked: SystemTime, now: SystemTime, interval: Duration) -> b
 /// 啟動檢查與週期檢查共用同一個節流判斷——名字不叫 `on_startup` 是因為
 /// `spawn_check(manual = false)` 兩種觸發時機都會走到這裡。
 fn should_check_now(interval: Duration) -> bool {
-    let Some(path) = existing_marker_path() else {
+    let Some(path) = existing_marker_path(UPDATE_CHECK_MARKER_FILE_NAME) else {
         return true;
     };
     let Ok(modified) = fs::metadata(&path).and_then(|m| m.modified()) else {
@@ -446,21 +506,75 @@ fn should_check_now(interval: Duration) -> bool {
     check_due(modified, SystemTime::now(), interval)
 }
 
-/// 寫入用：先試優先層，寫失敗（唯讀目錄）才退到暫存目錄。
 pub fn mark_checked() {
-    if let Some(primary) = primary_marker_path() {
-        if touch(&primary) {
-            return;
-        }
-    }
-    touch(&fallback_marker_path());
+    write_marker(UPDATE_CHECK_MARKER_FILE_NAME, "");
 }
 
-fn touch(path: &Path) -> bool {
-    if let Some(dir) = path.parent() {
-        let _ = fs::create_dir_all(dir);
+// ── Release notes：版本變了、第一次啟動時跳出當版 CHANGELOG 區塊 ──
+//
+// marker 兩層路徑的既有毛病在這裡症狀較重：`existing_marker_path` 讀取時
+// 只要優先層存在就用它。若優先層存在但事後變成不可寫，寫入會退到暫存層、
+// 讀取卻仍讀到優先層的舊版號，導致每次啟動都誤判成「沒看過新版」而重跳。
+// `.ysgit.update_check` 有同一個毛病，但後果只是多查幾次更新；這裡的後果
+// 是使用者每次啟動都被擋一下，嚴重度差一個量級——場景仍然罕見（需要優先
+// 層先寫成功、之後才變唯讀），不特別處理，但不能跟 `.ysgit.update_check`
+// 混為一談。
+
+/// 抽出 `## [version]` 那一節（含標題行），起點與終點都 anchor 到行首。
+/// 跟 `.github/scripts/prepare_release.py::extract_changelog_section` 是
+/// 同一條規則的 Rust 版——這裡比 python 版更嚴謹（那邊起點沒 anchor）：
+/// 不 anchor 起點的話，commit 訊息內文剛好出現 `## [1.0.0]` 這種字串會被
+/// 誤切，TUI 顯示的內容就會跟 GitHub Release 實際的 body 不一致。
+fn extract_release_notes(changelog: &'static str, version: &str) -> Option<&'static str> {
+    let marker = format!("\n## [{version}]");
+    let marker_pos = changelog.find(&marker)?;
+    let start = marker_pos + 1; // 跳過 anchor 用的換行，區塊本身從 `##` 開始
+    let rest = &changelog[start..];
+    let end = rest.find("\n## [").unwrap_or(rest.len());
+    let section = rest[..end].trim();
+    (!section.is_empty()).then_some(section)
+}
+
+/// marker 檔可能被 `echo` 或編輯器補上結尾換行，不 trim 會讓已看過的版本
+/// 每次啟動都被誤判成「沒看過」而重跳。
+fn should_show(seen: Option<&str>, current: &str) -> bool {
+    seen.map(str::trim) != Some(current)
+}
+
+fn read_seen_version() -> Option<String> {
+    let path = existing_marker_path(SEEN_VERSION_MARKER_FILE_NAME)?;
+    fs::read_to_string(path).ok()
+}
+
+/// `app.rs::open_release_notes()` 專用：release notes view 真的建出來、
+/// 下一幀就會畫出來的當下才算「看過」。
+pub fn mark_version_seen() {
+    write_marker(SEEN_VERSION_MARKER_FILE_NAME, env!("CARGO_PKG_VERSION"));
+}
+
+/// 這次啟動該顯示的 release notes，沒有就 `None`。**不寫 marker**——寫入
+/// 時機在 `mark_version_seen()`，故意跟這個函式分開：`lib.rs::run()` 呼叫
+/// 這裡之後還有 `git::Repository::load(...)?` 這類會早退的路徑，若在這裡
+/// 就寫 marker，非 git 目錄啟動會讓 marker 寫下去但畫面從沒出現過，這一版
+/// 的 notes 就永遠看不到了。
+///
+/// debug build 不自動跳：`cargo clean` 後每次 `cargo run` 都會被擋在
+/// commit list 前面，跟 `download_and_replace` 的 `cfg!(debug_assertions)`
+/// 早退同一個先例。`--whats-new` 不受這個限制，隨時能手動看。
+pub fn pending_release_notes(settings: UpdateSettings) -> Option<&'static str> {
+    if cfg!(debug_assertions) || !settings.release_notes {
+        return None;
     }
-    fs::File::create(path).is_ok()
+    if !should_show(read_seen_version().as_deref(), env!("CARGO_PKG_VERSION")) {
+        return None;
+    }
+    current_release_notes()
+}
+
+/// 目前這一版的 release notes，跟版本設定、marker 都無關——`--whats-new`
+/// 用它隨時手動查看，不受 `pending_release_notes()` 那些節流／開關限制。
+pub fn current_release_notes() -> Option<&'static str> {
+    extract_release_notes(CHANGELOG, env!("CARGO_PKG_VERSION"))
 }
 
 // ── 殘檔清掃：process 被砍掉（SIGKILL、斷電）時來不及跑到
@@ -819,16 +933,19 @@ ca0a1ac34d2e1138b9308820e3a53b6822552268907e87a11a1350b98f1a6ada  ysgit_2.4.1-ma
                 mode: Some(UpdateMode::Auto),
                 interval_hours: Some(2),
                 auto_restart: Some(AutoRestart::On),
+                release_notes: Some(ReleaseNotes::Off),
             },
             UpdateOverrides {
                 mode: Some(UpdateMode::Off),
                 interval_hours: Some(20),
                 auto_restart: Some(AutoRestart::Off),
+                release_notes: Some(ReleaseNotes::On),
             },
         );
         assert_eq!(settings.mode, UpdateMode::Auto);
         assert_eq!(settings.interval, Duration::from_secs(2 * 3600));
         assert!(settings.auto_restart);
+        assert!(!settings.release_notes);
     }
 
     #[test]
@@ -839,11 +956,13 @@ ca0a1ac34d2e1138b9308820e3a53b6822552268907e87a11a1350b98f1a6ada  ysgit_2.4.1-ma
                 mode: Some(UpdateMode::Off),
                 interval_hours: Some(20),
                 auto_restart: Some(AutoRestart::On),
+                release_notes: Some(ReleaseNotes::Off),
             },
         );
         assert_eq!(settings.mode, UpdateMode::Off);
         assert_eq!(settings.interval, Duration::from_secs(20 * 3600));
         assert!(settings.auto_restart);
+        assert!(!settings.release_notes);
     }
 
     #[test]
@@ -855,6 +974,101 @@ ca0a1ac34d2e1138b9308820e3a53b6822552268907e87a11a1350b98f1a6ada  ysgit_2.4.1-ma
             Duration::from_secs(DEFAULT_INTERVAL_HOURS * 3600)
         );
         assert!(!settings.auto_restart);
+        assert!(settings.release_notes);
+    }
+
+    // ── extract_release_notes()：CHANGELOG 區塊切割 ──
+
+    const TEST_CHANGELOG: &str = "\
+# Changelog
+
+## [3.0.0](url) (2026-08-13)
+
+### Features
+
+* first (abc)
+
+## [2.7.3](url) (2026-08-12)
+
+### Refactors
+
+* second (def)
+
+## [2.7.2](url) (2026-08-11)
+
+### Bug Fixes
+
+* third (ghi)
+";
+
+    #[test]
+    fn extract_release_notes_first_section() {
+        let section = extract_release_notes(TEST_CHANGELOG, "3.0.0").unwrap();
+        assert!(section.starts_with("## [3.0.0]"));
+        assert!(section.contains("first (abc)"));
+    }
+
+    #[test]
+    fn extract_release_notes_middle_section() {
+        let section = extract_release_notes(TEST_CHANGELOG, "2.7.3").unwrap();
+        assert!(section.starts_with("## [2.7.3]"));
+        assert!(section.contains("second (def)"));
+    }
+
+    #[test]
+    fn extract_release_notes_last_section() {
+        let section = extract_release_notes(TEST_CHANGELOG, "2.7.2").unwrap();
+        assert!(section.starts_with("## [2.7.2]"));
+        assert!(section.contains("third (ghi)"));
+    }
+
+    #[test]
+    fn extract_release_notes_missing_version_is_none() {
+        assert!(extract_release_notes(TEST_CHANGELOG, "9.9.9").is_none());
+    }
+
+    #[test]
+    fn extract_release_notes_does_not_bleed_into_next_section() {
+        let section = extract_release_notes(TEST_CHANGELOG, "3.0.0").unwrap();
+        assert!(!section.contains("second (def)"));
+        assert!(!section.contains("## [2.7.3]"));
+    }
+
+    #[test]
+    fn current_version_has_a_changelog_section() {
+        // 唯一一條會抓到真問題的測試：Cargo.toml 版號跟 CHANGELOG.md 脫節
+        // （忘了在 release 流程外手動改版號、或 CHANGELOG 沒同步）時直接紅燈。
+        assert!(current_release_notes().is_some());
+    }
+
+    // ── should_show()：marker 記錄的版本 vs 目前版本 ──
+
+    #[test]
+    fn should_show_no_marker_is_true() {
+        assert!(should_show(None, "3.0.0"));
+    }
+
+    #[test]
+    fn should_show_same_version_is_false() {
+        assert!(!should_show(Some("3.0.0"), "3.0.0"));
+    }
+
+    #[test]
+    fn should_show_trims_trailing_newline() {
+        // marker 檔可能被 `echo`（而非 `printf`）或編輯器補上結尾換行。
+        assert!(!should_show(Some("3.0.0\n"), "3.0.0"));
+    }
+
+    #[test]
+    fn should_show_upgraded_version_is_true() {
+        assert!(should_show(Some("2.0.0"), "3.0.0"));
+    }
+
+    #[test]
+    fn should_show_downgraded_version_is_true() {
+        // 刻意不用 semver 比大小：rollback 後也該看得到自己實際在跑的版本
+        // 說明，不是「只有升版才顯示」。
+        assert!(should_show(Some("3.0.0"), "2.0.0"));
     }
 
     // ── check_due()：邊界 ──

--- a/src/view.rs
+++ b/src/view.rs
@@ -9,6 +9,7 @@ mod help;
 mod list;
 mod markdown;
 mod refs;
+mod release_notes;
 pub(crate) mod user_command;
 
 pub use refs::RefsOrigin;

--- a/src/view/help.rs
+++ b/src/view/help.rs
@@ -55,6 +55,7 @@ enum HelpBlock {
     DeleteTag,
     DeleteRef,
     UserCommand,
+    ReleaseNotes,
 }
 
 impl HelpBlock {
@@ -70,6 +71,7 @@ impl HelpBlock {
             HelpBlock::DeleteTag => "Delete Tag",
             HelpBlock::DeleteRef => "Delete Ref",
             HelpBlock::UserCommand => "User Command",
+            HelpBlock::ReleaseNotes => "Release Notes",
         }
     }
 
@@ -94,6 +96,7 @@ impl HelpBlock {
             HelpBlock::DeleteTag => &["src/view/delete_tag.rs"],
             HelpBlock::DeleteRef => &["src/view/delete_ref.rs"],
             HelpBlock::UserCommand => &["src/view/user_command.rs"],
+            HelpBlock::ReleaseNotes => &["src/view/release_notes.rs"],
         }
     }
 }
@@ -413,17 +416,30 @@ fn help_blocks(
     list.extend(user_command_items.iter().cloned());
     user_command.extend(user_command_items);
 
+    let release_notes = vec![
+        b(vec![UserEvent::Quit], "離開（按兩下）", "Quit (press twice)"),
+        b(vec![UserEvent::Cancel, UserEvent::Close, UserEvent::NavigateLeft],
+            "關閉 release notes", "Close release notes"),
+        b(vec![UserEvent::NavigateDown, UserEvent::SelectDown], "向下捲動", "Scroll down"),
+        b(vec![UserEvent::NavigateUp,   UserEvent::SelectUp],   "向上捲動", "Scroll up"),
+        b(vec![UserEvent::PageDown],     "向下一頁", "Scroll page down"),
+        b(vec![UserEvent::PageUp],       "向上一頁", "Scroll page up"),
+        b(vec![UserEvent::HalfPageDown], "向下半頁", "Scroll half page down"),
+        b(vec![UserEvent::HalfPageUp],   "向上半頁", "Scroll half page up"),
+    ];
+
     vec![
-        (HelpBlock::Common,      common),
-        (HelpBlock::Help,        help),
-        (HelpBlock::List,        list),
-        (HelpBlock::Detail,      detail),
-        (HelpBlock::Refs,        refs),
-        (HelpBlock::GitHub,      github),
-        (HelpBlock::CreateTag,   create_tag),
-        (HelpBlock::DeleteTag,   delete_tag),
-        (HelpBlock::DeleteRef,   delete_ref),
-        (HelpBlock::UserCommand, user_command),
+        (HelpBlock::Common,       common),
+        (HelpBlock::Help,         help),
+        (HelpBlock::List,         list),
+        (HelpBlock::Detail,       detail),
+        (HelpBlock::Refs,         refs),
+        (HelpBlock::GitHub,       github),
+        (HelpBlock::CreateTag,    create_tag),
+        (HelpBlock::DeleteTag,    delete_tag),
+        (HelpBlock::DeleteRef,    delete_ref),
+        (HelpBlock::UserCommand,  user_command),
+        (HelpBlock::ReleaseNotes, release_notes),
     ]
 }
 

--- a/src/view/release_notes.rs
+++ b/src/view/release_notes.rs
@@ -1,0 +1,128 @@
+use std::rc::Rc;
+
+use ratatui::{
+    crossterm::event::KeyEvent,
+    layout::Rect,
+    style::Style,
+    widgets::{Block, Borders, Padding, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::{
+    app::AppContext,
+    event::{AppEvent, Sender, UserEvent, UserEventWithCount},
+    view::View,
+};
+
+/// 更新後（或全新安裝）第一次啟動時跳出的 overlay，內容是這一版
+/// `CHANGELOG.md` 的區塊（`update::extract_release_notes` 抽出來的）。
+/// 結構照 `HelpView`：持有 `before` 供 Esc/q 關閉時展開回去。
+///
+/// 不重用 `widget::output_pane::OutputPane`：那個 widget 的 `Paragraph`
+/// 沒開 `.wrap()`，`skip(offset).take(height)` 假設一個原始行對應一個視覺
+/// 行——這對它現有的兩個用途（diff、user command 的 ANSI 輸出）是對的，
+/// 但 CHANGELOG 條目常常是一整行很長的中文描述，不折行會被硬截斷在畫面
+/// 右緣。這裡改成跟 `view/github/render.rs::render_preview` 一樣的模式：
+/// 自己管一個 `offset`／`height`，`Paragraph` 開 `.wrap(Wrap { trim: false })`
+/// 做詞界折行，`.scroll()` 的單位是折行後的視覺行、不是原始行。
+#[derive(Debug)]
+pub struct ReleaseNotesView<'a> {
+    before: View<'a>,
+    body: &'static str,
+    offset: usize,
+    /// 上一次 render 量到的可視高度（折行後的列數），PageDown／
+    /// HalfPageDown 換算頁距要用；下一幀 render 會重新量測。
+    height: usize,
+    ctx: Rc<AppContext>,
+    tx: Sender,
+}
+
+impl<'a> ReleaseNotesView<'a> {
+    pub fn new(
+        before: View<'a>,
+        body: &'static str,
+        ctx: Rc<AppContext>,
+        tx: Sender,
+    ) -> ReleaseNotesView<'a> {
+        ReleaseNotesView {
+            before,
+            body,
+            offset: 0,
+            height: 0,
+            ctx,
+            tx,
+        }
+    }
+
+    pub fn take_before_view(&mut self) -> View<'a> {
+        std::mem::take(&mut self.before)
+    }
+
+    pub fn handle_event(&mut self, event_with_count: UserEventWithCount, _: KeyEvent) {
+        let event = event_with_count.event;
+        let count = event_with_count.count;
+
+        match event {
+            UserEvent::Quit => {
+                self.tx.send(AppEvent::Quit);
+            }
+            UserEvent::Cancel | UserEvent::Close | UserEvent::NavigateLeft => {
+                self.tx.send(AppEvent::CloseReleaseNotes);
+            }
+            UserEvent::NavigateDown | UserEvent::SelectDown => self.scroll_down(count),
+            UserEvent::NavigateUp | UserEvent::SelectUp => self.scroll_up(count),
+            UserEvent::PageDown => self.scroll_down(self.page().saturating_mul(count)),
+            UserEvent::PageUp => self.scroll_up(self.page().saturating_mul(count)),
+            UserEvent::HalfPageDown => self.scroll_down((self.page() / 2).saturating_mul(count)),
+            UserEvent::HalfPageUp => self.scroll_up((self.page() / 2).saturating_mul(count)),
+            _ => {}
+        }
+    }
+
+    /// `height` 是「上一幀量到的可視高度」，Page／HalfPage 換算頁距共用
+    /// 這個下限——高度還沒量過（第一幀）或量到 0 時，一頁至少要能挪動
+    /// 一行，不能卡死在原地。
+    fn page(&self) -> usize {
+        self.height.max(1)
+    }
+
+    fn scroll_down(&mut self, n: usize) {
+        self.offset = self.offset.saturating_add(n);
+    }
+
+    fn scroll_up(&mut self, n: usize) {
+        self.offset = self.offset.saturating_sub(n);
+    }
+
+    /// 沒有內容快取：CHANGELOG 一節通常只有 10–60 行，`markdown::render`
+    /// 是逐行純字串處理，這個 view 也沒有 marquee（只有按鍵才會重畫），
+    /// 不值得為它另外維護一個依 width 判斷的快取（對比
+    /// `github/preview.rs::PreviewCache`——那裡是幾百則留言的 timeline，
+    /// 量級完全不同）。
+    pub fn render(&mut self, f: &mut Frame, area: Rect) {
+        let block = Block::default()
+            .borders(Borders::TOP)
+            .style(Style::default().fg(self.ctx.color_theme.divider_fg))
+            .padding(Padding::horizontal(2))
+            .title_top(" Release Notes ");
+        let inner = block.inner(area);
+        self.height = inner.height as usize;
+
+        let lines = super::markdown::render(self.body, inner.width as usize);
+        let paragraph = Paragraph::new(lines)
+            .style(Style::default().fg(self.ctx.color_theme.fg))
+            .wrap(Wrap { trim: false });
+
+        // 折行後的視覺行數要在掛 `block` 之前量：`line_count` 會把 block
+        // 的 vertical space（這裡是 `Borders::TOP` 那一列）算進去，用同一個
+        // Paragraph 掛完 block 再量會多算一列。
+        let max_offset = paragraph
+            .line_count(inner.width)
+            .saturating_sub(self.height)
+            .min(u16::MAX as usize);
+        self.offset = self.offset.min(max_offset);
+
+        let paragraph = paragraph.block(block).scroll((self.offset as u16, 0));
+        f.render_widget(paragraph, area);
+    }
+}

--- a/src/view/views.rs
+++ b/src/view/views.rs
@@ -9,7 +9,7 @@ use crate::{
     view::{
         create_tag::CreateTagView, delete_ref::DeleteRefView, delete_tag::DeleteTagView,
         detail::DetailView, github::GitHubView, help::HelpView, list::ListView, refs::RefsView,
-        user_command::UserCommandView, RefsOrigin,
+        release_notes::ReleaseNotesView, user_command::UserCommandView, RefsOrigin,
     },
     widget::{commit_list::CommitListState, ref_list::RefListState},
 };
@@ -27,6 +27,7 @@ pub enum View<'a> {
     DeleteRef(Box<DeleteRefView<'a>>),
     Help(Box<HelpView<'a>>),
     GitHub(Box<GitHubView<'a>>),
+    ReleaseNotes(Box<ReleaseNotesView<'a>>),
 }
 
 impl<'a> View<'a> {
@@ -42,6 +43,7 @@ impl<'a> View<'a> {
             View::DeleteRef(view) => view.handle_event(event_with_count, key_event),
             View::Help(view) => view.handle_event(event_with_count, key_event),
             View::GitHub(view) => view.handle_event(event_with_count, key_event),
+            View::ReleaseNotes(view) => view.handle_event(event_with_count, key_event),
         }
     }
 
@@ -57,6 +59,7 @@ impl<'a> View<'a> {
             View::DeleteRef(view) => view.render(f, area),
             View::Help(view) => view.render(f, area),
             View::GitHub(view) => view.render(f, area, marquee_frame),
+            View::ReleaseNotes(view) => view.render(f, area),
         }
     }
 
@@ -107,7 +110,8 @@ impl<'a> View<'a> {
             | View::DeleteTag(_)
             | View::DeleteRef(_)
             | View::Help(_)
-            | View::GitHub(_) => false,
+            | View::GitHub(_)
+            | View::ReleaseNotes(_) => false,
         }
     }
 
@@ -271,6 +275,15 @@ impl<'a> View<'a> {
         View::GitHub(Box::new(GitHubView::new(before, data, tx)))
     }
 
+    pub fn of_release_notes(
+        before: View<'a>,
+        body: &'static str,
+        ctx: Rc<AppContext>,
+        tx: Sender,
+    ) -> Self {
+        View::ReleaseNotes(Box::new(ReleaseNotesView::new(before, body, ctx, tx)))
+    }
+
     pub fn refresh(&mut self) {
         match self {
             View::Default => {}
@@ -283,6 +296,7 @@ impl<'a> View<'a> {
             View::DeleteRef(view) => view.refresh(),
             View::Help(_) => {}
             View::GitHub(_) => {}
+            View::ReleaseNotes(_) => {}
         }
     }
 
@@ -301,6 +315,7 @@ impl<'a> View<'a> {
                 // take_before_view 會留下 View::Default，但無妨，因為 `v` 接著就會被 drop。
                 View::Help(mut v) => v.take_before_view(),
                 View::GitHub(mut v) => v.take_before_view(),
+                View::ReleaseNotes(mut v) => v.take_before_view(),
                 View::Default => unreachable!("no View::Default at runtime"),
             };
         }

--- a/src/wizard/mod.rs
+++ b/src/wizard/mod.rs
@@ -18,7 +18,7 @@ use tui_input::backend::crossterm::EventHandler;
 use crate::{
     color::ColorTheme,
     config, keybind,
-    update::{self, AutoRestart, UpdateMode},
+    update::{self, AutoRestart, ReleaseNotes, UpdateMode},
     Args, CommitOrderType, CompactType, GraphStyle, GraphWidthType, InitialSelection,
 };
 
@@ -157,6 +157,13 @@ fn auto_restart_desc(v: AutoRestart) -> &'static str {
     }
 }
 
+fn release_notes_desc(v: ReleaseNotes) -> &'static str {
+    match v {
+        ReleaseNotes::Off => "關閉",
+        ReleaseNotes::On => "開啟",
+    }
+}
+
 /// 精靈顯示「目前值」與循環切換起點用的參考點。跟 `src/lib.rs` 的 `run()`
 /// 裡 `args.field.or(core_config.option.field)` 那條合併鏈讀的是同一份
 /// 設定檔，語意也一樣（沒被使用者這次 session 動過的欄位，最終生效的值
@@ -177,6 +184,7 @@ struct ResolvedDefaults {
     update_mode: UpdateMode,
     update_interval: u64,
     auto_restart: AutoRestart,
+    release_notes: ReleaseNotes,
     /// 顏色編輯器的預覽基準（使用者實際設定，不是 `wizard::run()` 固定用
     /// 的畫面 chrome）。
     theme: ColorTheme,
@@ -228,6 +236,7 @@ impl ResolvedDefaults {
                 .interval_hours
                 .unwrap_or(update::DEFAULT_INTERVAL_HOURS),
             auto_restart: core.update.auto_restart.unwrap_or_default(),
+            release_notes: core.update.release_notes.unwrap_or_default(),
             theme,
             keybind_patch: keybind_patch.unwrap_or_default(),
             user_commands,
@@ -322,6 +331,7 @@ enum CycleField {
     InitialSelection,
     UpdateMode,
     AutoRestart,
+    ReleaseNotes,
 }
 
 impl CycleField {
@@ -336,6 +346,7 @@ impl CycleField {
             CycleField::InitialSelection => (CORE_OPTION, "initial_selection"),
             CycleField::UpdateMode => (CORE_UPDATE, "mode"),
             CycleField::AutoRestart => (CORE_UPDATE, "auto_restart"),
+            CycleField::ReleaseNotes => (CORE_UPDATE, "release_notes"),
         };
         ConfigKey {
             table,
@@ -352,6 +363,7 @@ impl CycleField {
             CycleField::InitialSelection => "-i, --initial-selection",
             CycleField::UpdateMode => "--update-mode",
             CycleField::AutoRestart => "--auto-restart",
+            CycleField::ReleaseNotes => "--release-notes",
         }
     }
 
@@ -364,6 +376,7 @@ impl CycleField {
             CycleField::InitialSelection => "初始選取的 commit",
             CycleField::UpdateMode => "自動更新檢查模式",
             CycleField::AutoRestart => "更新後自動重啟／開啟新版",
+            CycleField::ReleaseNotes => "更新後跳出 release notes",
         }
     }
 
@@ -392,6 +405,9 @@ impl CycleField {
             CycleField::AutoRestart => {
                 cycle_value(&mut args.auto_restart, defaults.auto_restart, delta)
             }
+            CycleField::ReleaseNotes => {
+                cycle_value(&mut args.release_notes, defaults.release_notes, delta)
+            }
         };
         draft.edits.insert(self.config_key(), Some(name.into()));
     }
@@ -417,6 +433,9 @@ impl CycleField {
             }
             CycleField::AutoRestart => {
                 auto_restart_desc(args.auto_restart.unwrap_or(defaults.auto_restart))
+            }
+            CycleField::ReleaseNotes => {
+                release_notes_desc(args.release_notes.unwrap_or(defaults.release_notes))
             }
         }
     }
@@ -621,6 +640,7 @@ const ROWS: &[RowAction] = &[
     RowAction::Edit(Editor::Cycle(CycleField::UpdateMode)),
     RowAction::Edit(Editor::Dialog(Dialog::Number(NumberField::UpdateInterval))),
     RowAction::Edit(Editor::Cycle(CycleField::AutoRestart)),
+    RowAction::Edit(Editor::Cycle(CycleField::ReleaseNotes)),
     RowAction::Edit(Editor::Dialog(Dialog::ColorMenu)),
     RowAction::Edit(Editor::Dialog(Dialog::KeyBindMenu)),
     RowAction::Launch,
@@ -1346,6 +1366,21 @@ mod tests {
     }
 
     #[test]
+    fn release_notes_row_toggles() {
+        let mut s = test_state();
+        let idx = row_of_field(CycleField::ReleaseNotes);
+        move_to_row(&mut s, idx);
+        assert_eq!(s.draft.args.release_notes, None);
+
+        s.on_key(key(KeyCode::Right));
+        assert_eq!(
+            s.draft.args.release_notes,
+            Some(ReleaseNotes::Off),
+            "on 是目前值，第一次按 → 跳過它，切到下一個 off"
+        );
+    }
+
+    #[test]
     fn right_on_path_row_also_opens_the_browser() {
         let mut s = test_state();
         assert!(matches!(
@@ -1666,12 +1701,12 @@ mod tests {
 
     // ── 新架構釘住的不變式：ConfigKey 對應表、空 edits、PATH 的隔離 ──
 
-    /// 9 個項目全部碰過一遍，寫回、再用真正的設定檔 parser（不是自己重抄一份
-    /// 反序列化邏輯）讀回來逐欄位比對。這條測試同時證明 9 條表路徑、9 個鍵名
-    /// （`update_mode` 寫的是 `mode`、`update_interval` 寫的是 `interval_hours`，
-    /// 兩個鍵名跟欄位名不同，最容易打錯）、9 個字串值全對——`toml_edit` 只認
-    /// 語法不認語意，鍵名寫錯不會有任何編譯期或執行期警訊，只有真的讀回來
-    /// 比對值才抓得到。
+    /// 10 個項目全部碰過一遍，寫回、再用真正的設定檔 parser（不是自己重抄
+    /// 一份反序列化邏輯）讀回來逐欄位比對。這條測試同時證明 10 條表路徑、
+    /// 10 個鍵名（`update_mode` 寫的是 `mode`、`update_interval` 寫的是
+    /// `interval_hours`，兩個鍵名跟欄位名不同，最容易打錯）、10 個字串值
+    /// 全對——`toml_edit` 只認語法不認語意，鍵名寫錯不會有任何編譯期或
+    /// 執行期警訊，只有真的讀回來比對值才抓得到。
     #[test]
     fn every_field_round_trips_through_the_real_config_parser() {
         let mut s = test_state();
@@ -1683,6 +1718,7 @@ mod tests {
             CycleField::InitialSelection,
             CycleField::UpdateMode,
             CycleField::AutoRestart,
+            CycleField::ReleaseNotes,
         ] {
             field.cycle(&mut s.draft, &s.defaults, 1);
         }
@@ -1704,6 +1740,7 @@ mod tests {
         assert_eq!(core.update.mode, s.draft.args.update_mode);
         assert_eq!(core.update.interval_hours, s.draft.args.update_interval);
         assert_eq!(core.update.auto_restart, s.draft.args.auto_restart);
+        assert_eq!(core.update.release_notes, s.draft.args.release_notes);
     }
 
     /// 新架構才有的保證：`edits` 是空的，`apply_touched_settings` 一次

--- a/tests/help_flag.rs
+++ b/tests/help_flag.rs
@@ -42,6 +42,8 @@ fn help_output_lists_every_flag_including_the_new_path_browser() {
         "--update-mode",
         "--update-interval",
         "--auto-restart",
+        "--release-notes",
+        "--whats-new",
         "-h, --help",
         "-V, --version",
         "-U, --update",


### PR DESCRIPTION
## 變更摘要

- 版本變了（或全新安裝）第一次啟動時自動跳出當版 CHANGELOG 區塊，全螢幕可捲動 view，Esc/q 關閉
- 內容直接讀內嵌的 CHANGELOG.md 抽出對應版本區塊，不打 GitHub API、不連網
- 新增 `core.update.release_notes` 設定與 `--release-notes <on|off>` 開關（debug build 不自動跳，避免 `cargo run` 每次都被擋住）
- 新增 `--whats-new` 隨時手動查看目前版本的 release notes，不受開關限制
- wizard（`-h`）同步新增對應設定列，說明頁（`?`）與 `docs/src/keybindings/index.md` 同步補上新 view 的鍵位

Closes #73

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --verbose` 通過
- [x] release build 手動測試：首次啟動跳出、關閉後不再跳、`echo` 換行結尾不誤判、`--release-notes off` 生效、debug build 不自動跳、`-h` 精靈可切換