### PR TITLE
fix: 自動更新加上下載中提示，並避免凍結使用者輸入 (#77)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -680,7 +680,19 @@ impl App<'_> {
                     self.maybe_open_update_prompt(tag);
                 }
                 AppEvent::UpdateRequested { tag } => {
-                    spawn_update_download(self.ec, tag);
+                    // `spawn_update_download` 一啟動就蓋全螢幕 pending overlay、
+                    // 凍結鍵盤（`handle_key` 對 `pending_message.is_some()` 的
+                    // 處理）。手動確認這條路徑一定過得了這個守衛——
+                    // `handle_yes_no_prompt_key` 送這個事件前已經
+                    // `mem::take` 清空 `status_line_state`，`can_interrupt()`
+                    // 這時必為真；真正靠這個守衛擋下的是 `mode = Auto` 背景
+                    // 觸發的那一路，避免使用者在輸入框打字打到一半被憑空
+                    // 凍結。沒過就靜默跳過，等下一個 interval——跟
+                    // `maybe_open_update_prompt` 守衛沒過就不開提示同一套
+                    // 哲學。
+                    if self.can_interrupt() {
+                        spawn_update_download(self.ec, tag);
+                    }
                 }
                 AppEvent::UpdateInstalled { tag, exe } => {
                     // auto_restart 開著時不問，但仍要走 can_interrupt()

--- a/src/event.rs
+++ b/src/event.rs
@@ -199,7 +199,9 @@ pub enum AppEvent {
     OpenUpdatePrompt {
         tag: String,
     },
-    /// 使用者在更新提示按下確認。
+    /// 開始下載＋替換執行檔。兩個觸發來源：使用者在更新提示按下確認，或
+    /// `mode = Auto` 查到新版直接送（跳過詢問）。理由與守衛見
+    /// `update::spawn_check` 和處理端 `app.rs::spawn_update_download`。
     UpdateRequested {
         tag: String,
     },

--- a/src/update.rs
+++ b/src/update.rs
@@ -167,9 +167,15 @@ pub fn resolve(cli: UpdateOverrides, config: UpdateOverrides) -> UpdateSettings 
 /// - 手動：繞過節流與 `mode = Off`（使用者當下的明確意圖，跟「程式自作
 ///   主張背景檢查」是兩回事），任何結果都要吭聲——包括執行檔已被替換。
 ///
-/// `mode = Auto` 時（不論手動或自動觸發）查到新版直接下載替換，不彈 y/n
-/// 提示——跟 `-U` 在 `mode = Auto` 下跳過 confirm 是同一個承諾，不因為
-/// 觸發來源是背景 thread 還是使用者按鍵而有兩套行為。
+/// `mode = Auto` 時（不論手動或自動觸發）查到新版直接送
+/// `AppEvent::UpdateRequested`，不彈 y/n 提示——跟 `-U` 在 `mode = Auto`
+/// 下跳過 confirm 是同一個承諾，不因為觸發來源是背景 thread 還是使用者
+/// 按鍵而有兩套行為。送事件而不在這裡直接呼叫 `download_and_replace`：
+/// 處理端 `app.rs::spawn_update_download` 會顯示「Downloading {tag}...」，
+/// 讓使用者知道正在下載＋替換執行檔，不能因為沒經過詢問就悄悄裝完。
+/// 那個處理端會蓋全螢幕遮罩並凍結鍵盤，所以背景觸發要先過
+/// `App::can_interrupt()` 這一關（見 `app.rs` 對 `UpdateRequested` 的
+/// 處理）才會真的開始下載，不能在使用者打字打到一半憑空搶走鍵盤。
 ///
 /// 兩種情況都會標記「已檢查」，手動觸發後下次啟動不會馬上又問一次。
 pub fn spawn_check(ec: &EventController, manual: bool, settings: UpdateSettings) {
@@ -191,10 +197,7 @@ pub fn spawn_check(ec: &EventController, manual: bool, settings: UpdateSettings)
         let result = check_for_update();
         mark_checked();
         match result {
-            Ok(Some(tag)) if auto_download => match download_and_replace(&tag) {
-                Ok(exe) => tx.send(AppEvent::UpdateInstalled { tag, exe }),
-                Err(e) => tx.send(AppEvent::NotifyError(e)),
-            },
+            Ok(Some(tag)) if auto_download => tx.send(AppEvent::UpdateRequested { tag }),
             Ok(Some(tag)) => tx.send(AppEvent::OpenUpdatePrompt { tag }),
             Ok(None) if manual => tx.send(AppEvent::NotifyInfo(format!(
                 "Already up to date (v{})",


### PR DESCRIPTION
## 變更摘要

- `core.update.mode = auto` 時，背景查到新版原本直接下載替換，完全繞過既有的「Downloading {tag}...」進度提示，使用者只會看到畫面突然沒反應
- `update.rs::spawn_check` 的 auto_download 分支改成送 `AppEvent::UpdateRequested`，交給既有的 `spawn_update_download` 處理，跟手動確認共用同一段下載＋提示邏輯
- 但這條路徑會蓋全螢幕 overlay 並凍結鍵盤，加上 `can_interrupt()` 守衛：背景觸發時使用者忙碌（正在輸入框打字等）就靜默跳過、等下一個 interval；手動確認一定過得了這個守衛（確認當下狀態列已清空），行為不受影響

Closes #77

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --verbose` 通過
- [x] 3 個 code-simplifier agent 平行審查（3/3 共識抓到 `can_interrupt()` 守衛缺口），已核對程式碼確認手動確認路徑不受影響後套用
- [ ] 實際下載流程需要真實的較新 GitHub release 才能端對端驗證，此環境無法觸發——邏輯上是接回既有、已在生產環境跑過的 `spawn_update_download` 路徑，未新寫渲染邏輯