### PR TITLE
feat: 新增內嵌命令列，支援 Working changes 列與使用者 shell alias (#79)

### DIFF
--- a/assets/default-keybind.toml
+++ b/assets/default-keybind.toml
@@ -50,6 +50,7 @@ delete_ref = ["d"]
 
 remote_refs_toggle = ["o"]
 github_toggle = ["g"]
+shell_toggle = ["/"]
 
 # 沒有預設鍵位，理由同 scroll_up/scroll_down。
 task_list_toggle = []

--- a/config.schema.json
+++ b/config.schema.json
@@ -221,6 +221,20 @@
             }
           },
           "additionalProperties": false
+        },
+        "shell": {
+          "type": "object",
+          "description": "Shell command settings for the inline command line (`/`).",
+          "properties": {
+            "command": {
+              "type": "array",
+              "description": "The `[program, flags...]` used to run commands, e.g. [\"zsh\", \"-i\", \"-c\"]. Unset auto-detects per platform / $SHELL: POSIX shells (sh/bash/zsh/dash/ksh/mksh/ash) get an extra \"-i\" so the command line can see aliases/functions defined in shell rc files; Windows uses [\"cmd\", \"/C\"]. If set, the last element must be a flag that accepts a command string (\"-c\" for POSIX shells).",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/docs/src/configurations/config-file-format.md
+++ b/docs/src/configurations/config-file-format.md
@@ -26,6 +26,31 @@ tab_width = 4
 [core.external]
 clipboard = "Auto"
 
+[core.shell]
+# 不設就自動判斷：非 Windows 用 `$SHELL`（沒有就退回 `sh`），POSIX shell
+# （sh/bash/zsh/dash/ksh/mksh/ash）額外帶 `-i` 讓內嵌命令列（`/`）吃得到
+# `~/.zshrc`、`~/.bashrc` 裡定義的 alias／function；Windows 用 `cmd /C`。
+# 若要自訂，最後一個元素必須是「接受一段指令字串」的旗標（POSIX 是
+# `-c`）——`["zsh"]` 這種缺旗標的設定不會被驗證擋下，只會在執行時靜靜跑出
+# 空輸出。
+# command = ["zsh", "-i", "-c"]
+#
+# `-i` 會讓每次執行都重新跑一次 shell 的初始化（oh-my-zsh、powerlevel10k
+# 這類框架實測約 0.6～1.2 秒），輸入列會顯示「running…」直到跑完。若要
+# 加速，可以在 rc 檔開頭偵測 `SERIE_SHELL` 環境變數（內嵌命令列執行時一律
+# 會設這個變數為 `1`）、及早 return 跳過主題／外掛：
+#
+#   if [[ -n $SERIE_SHELL ]]; then
+#     source ~/dotfiles/.zsh/aliases/*.zsh
+#     return
+#   fi
+#
+# 限制：指令的 stdin 固定是 `/dev/null`，不支援互動式指令（`git add -p`、
+# `git rebase -i`、不帶 `-m` 的 `git commit`）。輸出也不是連到 tty，git
+# 預設不會上色，要顏色請用 `git -c color.ui=always ...`，或搭配上面的
+# `SERIE_SHELL` 判斷在 rc 裡設 `CLICOLOR_FORCE=1`。背景工作（`cmd &`）會
+# 讓面板等到它結束才收得到輸出。
+
 [ui]
 cursor_type = "Native"
 refs_width = 26

--- a/docs/src/keybindings/index.md
+++ b/docs/src/keybindings/index.md
@@ -60,6 +60,7 @@
 | <kbd>f</kbd> | fetch 所有 remote | `fetch` |
 | <kbd>Space</kbd> | checkout 選取的 commit/ref | `checkout` |
 | <kbd>r</kbd> | 重新整理 | `refresh` |
+| <kbd>/</kbd> | 開啟命令列 | `shell_toggle` |
 
 ### Commit 詳情
 
@@ -90,6 +91,7 @@
 | <kbd>g</kbd> | 開啟 GitHub issues/PRs | `github_toggle` |
 | <kbd>F1</kbd> <kbd>?</kbd> | 開啟說明 | `help_toggle` |
 | <kbd>r</kbd> | 重新整理 | `refresh` |
+| <kbd>/</kbd> | 開啟命令列 | `shell_toggle` |
 
 ### Refs 清單
 
@@ -177,6 +179,13 @@
 | <kbd>Enter</kbd> <kbd>y</kbd> | 顯示 commit 詳情 | `confirm` |
 | <kbd>F1</kbd> <kbd>?</kbd> | 開啟說明 | `help_toggle` |
 
+### Shell 命令列
+
+| 按鍵 | 說明 | 設定鍵名 |
+| --- | --- | --- |
+| <kbd>Enter</kbd> <kbd>y</kbd> | 執行指令 | `confirm` |
+| <kbd>n</kbd> <kbd>Esc</kbd> | 關閉命令列 | `cancel` |
+
 ### Release Notes
 
 | 按鍵 | 說明 | 設定鍵名 |
@@ -202,3 +211,5 @@
 | <kbd>f</kbd> | 刪除 branch 確認 | 強制刪除 |
 | <kbd>Tab</kbd> <kbd>Shift-Tab</kbd> | Create tag 對話框 | 在欄位間移動 |
 | <kbd>Space</kbd> | Create tag 對話框（核取方塊） | 切換核取狀態 |
+| <kbd>↑</kbd> <kbd>↓</kbd> | Shell 命令列 | 瀏覽指令歷史 |
+| <kbd>PageUp</kbd> <kbd>PageDown</kbd> | Shell 命令列 | 捲動輸出面板 |

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,10 +13,11 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     color::{ColorTheme, GraphColorSet},
-    config::{CoreConfig, UiConfig, UserCommand, UserCommandType},
+    config::{CoreConfig, CoreShellConfig, UiConfig, UserCommand, UserCommandType},
     event::{AppEvent, EventController, UserEvent, UserEventWithCount},
     external::{
-        copy_to_clipboard, exec_user_command, exec_user_command_suspend, ExternalCommandParameters,
+        copy_to_clipboard, exec_user_command, exec_user_command_suspend, is_posix_shell,
+        ExternalCommandParameters,
     },
     git::{Commit, CommitHash, FileChange, Head, Ref, RefType, Repository},
     github::{
@@ -73,6 +74,43 @@ pub struct AppContext {
     /// 已合併 CLI／設定檔的自動更新設定，`update::spawn_check` 與
     /// `auto_restart` 的中斷判斷共用同一份，不各自再 `.or()` 一遍。
     pub update: UpdateSettings,
+    /// 內嵌命令列（`/`）執行指令用的 `[程式, 旗標...]`——已解析完成的
+    /// 最終值，不同於 `core_config.shell.command` 那個可能是 `None` 的
+    /// 原始設定，見 `resolve_shell_command`。
+    pub shell_command: Vec<String>,
+}
+
+/// `AppContext.shell_command` 的解析邏輯：設定檔的原始值到 `resolve_shell_command`
+/// 這裡就結束了，這是已經決定好「開什麼、帶什麼旗標」的最終值。`shell_env`
+/// 由呼叫端傳入（而不是內部呼叫 `env::var`），純函式，方便測試決定性。
+pub(crate) fn resolve_shell_command(cfg: &CoreShellConfig, shell_env: Option<&str>) -> Vec<String> {
+    if let Some(command) = &cfg.command {
+        return command.clone();
+    }
+    default_shell_command(shell_env)
+}
+
+#[cfg(target_os = "windows")]
+fn default_shell_command(_shell_env: Option<&str>) -> Vec<String> {
+    vec!["cmd".to_string(), "/C".to_string()]
+}
+
+/// 非 Windows 平台的自動判斷：`$SHELL`（沒有就退回 `sh`）——POSIX shell
+/// （`is_posix_shell` 的 basename allowlist）額外帶 `-i`，讓內嵌命令列吃得
+/// 到 `~/.zshrc`／`~/.bashrc` 定義的 alias／function（非互動 shell 只讀
+/// `~/.zshenv` 這類極簡設定檔，讀不到）；fish、nushell 這些不在表內的
+/// shell 不冒然加只有 POSIX shell 才認得的旗標。
+#[cfg(not(target_os = "windows"))]
+fn default_shell_command(shell_env: Option<&str>) -> Vec<String> {
+    let shell = shell_env
+        .filter(|s| !s.is_empty())
+        .unwrap_or("sh")
+        .to_string();
+    if is_posix_shell(&shell) {
+        vec![shell, "-i".to_string(), "-c".to_string()]
+    } else {
+        vec![shell, "-c".to_string()]
+    }
 }
 
 /// `q` 雙擊退出的判定結果。
@@ -398,6 +436,15 @@ impl App<'_> {
                 }
                 AppEvent::CloseGitHub => {
                     self.close_github();
+                }
+                AppEvent::OpenShell => {
+                    self.open_shell();
+                }
+                AppEvent::CloseShell => {
+                    self.close_shell();
+                }
+                AppEvent::ShellOutputReady => {
+                    self.view.poll_shell_output();
                 }
                 AppEvent::OpenReleaseNotes { body } => {
                     self.open_release_notes(body);
@@ -844,7 +891,8 @@ impl App<'_> {
     }
 
     fn is_input_mode(&self) -> bool {
-        self.status_line_state.is_input_mode_variant() || matches!(self.view, View::CreateTag(_))
+        self.status_line_state.is_input_mode_variant()
+            || matches!(self.view, View::CreateTag(_) | View::Shell(_))
     }
 
     fn current_list_refresh_context(&self) -> crate::view::ListRefreshViewContext {
@@ -1230,6 +1278,56 @@ impl App<'_> {
     fn close_help(&mut self) {
         if let View::Help(ref mut view) = self.view {
             self.view = view.take_before_view();
+            self.view.request_graph_clear();
+        }
+    }
+
+    fn open_shell(&mut self) {
+        let commit_list_state = match self.view {
+            View::List(ref mut view) => view.as_list_state(),
+            View::Detail(ref mut view) => view.as_list_state(),
+            _ => return,
+        };
+        // Working changes（virtual row）沒有真正的 commit，`selected_commit_hash`
+        // 會 fallback 回第一個 commit——`commit` 傳 `None`，`{{target_hash}}`
+        // 系列 marker 交給 `ShellView::run()` 判斷指令有沒有真的用到，用到
+        // 才報錯；`git status` 這類不含 marker 的指令照樣能在這一列跑。
+        let (commit, refs) = if commit_list_state.is_virtual_row_selected() {
+            (None, Vec::new())
+        } else {
+            let (commit, _, refs) = selected_commit_details(self.repository, commit_list_state);
+            (Some(commit), refs)
+        };
+        let area_width = self.view_area.width.saturating_sub(4); // 扣掉左右 padding
+        let area_height =
+            crate::view::shell::output_pane_height(self.view_area.height).saturating_sub(1); // 扣掉上邊框，跟 render() 用同一條公式
+        let repo_path = self.repository.path().to_path_buf();
+        // 在 `mem::take` 之前對還沒被包住的 List/Detail 設旗標——list/detail
+        // 底下多擠出一行輸入列，graph 是用終端圖形協定畫的，區域縮小不清
+        // 一次會留殘影。旗標設在這裡、`terminal.clear()` 由主迴圈的
+        // `take_graph_clear()` 統一執行（見 `View::Shell` 對它的委派），
+        // 不在這個 event arm 裡另外呼叫，才不會重複清兩次。
+        self.view.request_graph_clear();
+        let before_view = std::mem::take(&mut self.view);
+        self.view = View::of_shell(
+            before_view,
+            commit,
+            refs,
+            area_width,
+            area_height,
+            repo_path,
+            self.ctx.clone(),
+            self.ec.sender(),
+        );
+    }
+
+    fn close_shell(&mut self) {
+        if let View::Shell(ref mut view) = self.view {
+            let refresh_pending = view.take_refresh_pending();
+            self.view = view.take_before_view();
+            if refresh_pending {
+                self.view.refresh();
+            }
             self.view.request_graph_clear();
         }
     }
@@ -1972,14 +2070,17 @@ fn build_external_command_parameters_and_exec_command(
         .and_then(exec_user_command)
 }
 
-fn build_external_command_parameters<'a>(
+/// 兩條路徑共用的核心：把 `Commit` + `Ref` 分類成 `ExternalCommandParameters`
+/// 的各個 marker 欄位。`command` 與面積數字由呼叫端決定——user command 走
+/// 設定檔查表 + `pane_height.user_command`，shell 沒有查表、面積用自己的
+/// 輸出面板高度，兩者不該共用同一個公式（沿用對方的會給錯的數字）。
+pub(crate) fn external_command_parameters<'a>(
+    command: &'a [String],
     commit: &'a Commit,
     refs: &'a [Ref],
-    user_command_number: usize,
-    view_area: Rect,
-    ctx: &'a AppContext,
-) -> Result<ExternalCommandParameters<'a>, String> {
-    let command = &extract_user_command_by_number(user_command_number, ctx)?.commands;
+    area_width: u16,
+    area_height: u16,
+) -> ExternalCommandParameters<'a> {
     let target_hash = commit.commit_hash.as_str();
     let parent_hashes = commit
         .parent_commit_hashes
@@ -2005,11 +2106,7 @@ fn build_external_command_parameters<'a>(
         all_refs.push(r.name());
     }
 
-    let area_width = view_area.width.saturating_sub(4); // 扣掉左右 padding
-    let area_height = (view_area.height.saturating_sub(1))
-        .min(ctx.ui_config.pane_height.user_command)
-        .saturating_sub(1); // 扣掉上邊框
-    Ok(ExternalCommandParameters {
+    ExternalCommandParameters {
         command,
         target_hash,
         parent_hashes,
@@ -2020,7 +2117,28 @@ fn build_external_command_parameters<'a>(
         stash,
         area_width,
         area_height,
-    })
+    }
+}
+
+fn build_external_command_parameters<'a>(
+    commit: &'a Commit,
+    refs: &'a [Ref],
+    user_command_number: usize,
+    view_area: Rect,
+    ctx: &'a AppContext,
+) -> Result<ExternalCommandParameters<'a>, String> {
+    let command = &extract_user_command_by_number(user_command_number, ctx)?.commands;
+    let area_width = view_area.width.saturating_sub(4); // 扣掉左右 padding
+    let area_height = (view_area.height.saturating_sub(1))
+        .min(ctx.ui_config.pane_height.user_command)
+        .saturating_sub(1); // 扣掉上邊框
+    Ok(external_command_parameters(
+        command,
+        commit,
+        refs,
+        area_width,
+        area_height,
+    ))
 }
 
 #[cfg(test)]
@@ -2229,5 +2347,46 @@ mod tests {
         ks.reset_quit_press();
         let decision = ks.register_quit_press(t0 + Duration::from_millis(100));
         assert_eq!(decision, QuitDecision::First, "reset 之後視窗不該還算數");
+    }
+
+    #[test]
+    fn resolve_shell_command_prefers_explicit_config() {
+        let cfg = CoreShellConfig {
+            command: Some(vec!["fish".to_string(), "-c".to_string()]),
+        };
+        assert_eq!(
+            resolve_shell_command(&cfg, Some("zsh")),
+            vec!["fish".to_string(), "-c".to_string()]
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn resolve_shell_command_posix_shell_env_gets_interactive_flag() {
+        let cfg = CoreShellConfig { command: None };
+        assert_eq!(
+            resolve_shell_command(&cfg, Some("/bin/zsh")),
+            vec!["/bin/zsh".to_string(), "-i".to_string(), "-c".to_string()]
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn resolve_shell_command_non_posix_shell_env_skips_interactive_flag() {
+        let cfg = CoreShellConfig { command: None };
+        assert_eq!(
+            resolve_shell_command(&cfg, Some("fish")),
+            vec!["fish".to_string(), "-c".to_string()]
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn resolve_shell_command_missing_shell_env_falls_back_to_sh() {
+        let cfg = CoreShellConfig { command: None };
+        assert_eq!(
+            resolve_shell_command(&cfg, None),
+            vec!["sh".to_string(), "-i".to_string(), "-c".to_string()]
+        );
     }
 }

--- a/src/app/status_line.rs
+++ b/src/app/status_line.rs
@@ -77,6 +77,24 @@ fn build_hotkey_hints(view: &View, ctx: &AppContext) -> Line<'static> {
             h(&[UserEvent::Cancel], "cancel"),
         ],
         View::UserCommand(_) => crate::view::user_command::status_hints(),
+        // Up/Down／PageUp/PageDown 不經過 `KeyBind`（見
+        // `view::shell::resolve` 的文件註解），沒有 `UserEvent` 可以掛，早
+        // return 手動補上這兩組固定提示——其餘 view 都走尾端共用的
+        // `keybind_hint_line` 入口，不必為了這一個特例把它拆開。
+        View::Shell(_) => {
+            let mut pairs = hint_pairs(
+                &ctx.keybind,
+                &[
+                    h(&[UserEvent::Confirm], "run"),
+                    h(&[UserEvent::Cancel], "close"),
+                ],
+            );
+            pairs.extend([
+                ("↑↓".to_string(), "history"),
+                ("PgUp/PgDn".to_string(), "scroll"),
+            ]);
+            return hint_line(&ctx.color_theme, &pairs, ctx.color_theme.help_key_fg);
+        }
         View::Help(_) => vec![
             h(&[UserEvent::NavigateDown, UserEvent::NavigateUp], "scroll"),
             h(&[UserEvent::Close], "close"),
@@ -913,6 +931,7 @@ mod tests {
             graph_width: None,
             compact: None,
             update: crate::update::UpdateSettings::default(),
+            shell_command: Vec::new(),
         })
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,6 +164,9 @@ pub struct CoreConfig {
     pub external: CoreExternalConfig,
     #[garde(dive)]
     #[nested]
+    pub shell: CoreShellConfig,
+    #[garde(dive)]
+    #[nested]
     pub update: CoreUpdateConfig,
 }
 
@@ -357,6 +360,19 @@ pub struct CoreExternalConfig {
     #[garde(dive)]
     #[default(ClipboardConfig::Auto)]
     pub clipboard: ClipboardConfig,
+}
+
+/// 內嵌命令列（`/`）用什麼 shell 跑指令。`None` 交給執行期依平台／`$SHELL`
+/// 自動判斷（見 `app::resolve_shell_command`）——設定檔的原始值到這裡就
+/// 結束了，已解析出的最終指令放在 `AppContext.shell_command`。
+#[optional(derives = [Deserialize])]
+#[derive(Debug, Clone, PartialEq, Eq, SmartDefault, Validate)]
+pub struct CoreShellConfig {
+    /// 最後一個元素必須是「接受一段指令字串」的旗標（POSIX shell 是
+    /// `-c`）——`["zsh"]` 這種缺旗標的設定不會被這裡擋下，會在執行時
+    /// 靜靜跑出空輸出。
+    #[garde(length(min = 1))]
+    pub command: Option<Vec<String>>,
 }
 
 #[optional(derives = [Deserialize])]
@@ -724,6 +740,7 @@ mod tests {
                 external: CoreExternalConfig {
                     clipboard: ClipboardConfig::Auto,
                 },
+                shell: CoreShellConfig { command: None },
             },
             ui: UiConfig {
                 cursor_type: CursorType::Native,
@@ -865,6 +882,7 @@ mod tests {
                 external: CoreExternalConfig {
                     clipboard: ClipboardConfig::Auto,
                 },
+                shell: CoreShellConfig { command: None },
             },
             ui: UiConfig {
                 cursor_type: CursorType::Virtual("|".into()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -371,7 +371,7 @@ pub struct CoreShellConfig {
     /// 最後一個元素必須是「接受一段指令字串」的旗標（POSIX shell 是
     /// `-c`）——`["zsh"]` 這種缺旗標的設定不會被這裡擋下，會在執行時
     /// 靜靜跑出空輸出。
-    #[garde(length(min = 1))]
+    #[garde(length(min = 1), inner(inner(length(min = 1))))]
     pub command: Option<Vec<String>>,
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -57,6 +57,11 @@ pub enum AppEvent {
     CloseHelp,
     OpenGitHub,
     CloseGitHub,
+    OpenShell,
+    CloseShell,
+    /// 背景 thread 跑完 shell 指令了——不帶 payload，純喚醒；結果本身走
+    /// `ShellView` 自己持有的 `mpsc::Receiver`。見 `view/shell.rs` 頂端註解。
+    ShellOutputReady,
     /// 更新後（或全新安裝）第一次啟動時該顯示的 release notes——見
     /// `update::pending_release_notes`。`body` 是編譯期常數
     /// （`include_str!` 讀 `CHANGELOG.md`），不必轉成 `String`。
@@ -787,6 +792,7 @@ pub enum UserEvent {
     DeleteRef,
     RemoteRefsToggle,
     GitHubToggle,
+    ShellToggle,
     TaskListToggle,
     DetailPaneToggle,
     Fetch,
@@ -846,6 +852,7 @@ impl UserEvent {
             UserEvent::DeleteRef => "delete_ref",
             UserEvent::RemoteRefsToggle => "remote_refs_toggle",
             UserEvent::GitHubToggle => "github_toggle",
+            UserEvent::ShellToggle => "shell_toggle",
             UserEvent::TaskListToggle => "task_list_toggle",
             UserEvent::DetailPaneToggle => "detail_pane_toggle",
             UserEvent::Fetch => "fetch",
@@ -909,6 +916,7 @@ impl UserEvent {
             UserEvent::DeleteRef => "刪除 commit 上的 local branch",
             UserEvent::RemoteRefsToggle => "切換 remote refs",
             UserEvent::GitHubToggle => "開啟 GitHub issues/PRs",
+            UserEvent::ShellToggle => "開啟命令列",
             UserEvent::TaskListToggle => "切換 task 清單",
             UserEvent::DetailPaneToggle => "切換詳情區塊",
             UserEvent::Fetch => "fetch 所有 remote",
@@ -991,6 +999,7 @@ impl<'de> Deserialize<'de> for UserEvent {
                         "delete_ref" => Ok(UserEvent::DeleteRef),
                         "remote_refs_toggle" => Ok(UserEvent::RemoteRefsToggle),
                         "github_toggle" => Ok(UserEvent::GitHubToggle),
+                        "shell_toggle" => Ok(UserEvent::ShellToggle),
                         "task_list_toggle" => Ok(UserEvent::TaskListToggle),
                         "detail_pane_toggle" => Ok(UserEvent::DetailPaneToggle),
                         "fetch" => Ok(UserEvent::Fetch),

--- a/src/external.rs
+++ b/src/external.rs
@@ -2,14 +2,33 @@ use std::{
     cell::RefCell,
     env,
     fs::OpenOptions,
-    io::{self, Write},
+    io::{self, Read, Write},
     process::Command,
+    sync::{Arc, Mutex},
 };
 
 use arboard::Clipboard;
 use base64::{engine::general_purpose::STANDARD, Engine};
 
 use crate::config::ClipboardConfig;
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+// 手動宣告，不為了一個 syscall 拉整個 `libc` crate 進來——`exec_shell_command`
+// 用它讓 spawn 出來的 shell 跟 serie 的控制終端機斷開，見那裡的說明。
+#[cfg(unix)]
+extern "C" {
+    fn setsid() -> i32;
+}
+
+#[cfg(unix)]
+fn libc_setsid() -> i32 {
+    // SAFETY：`setsid()` 是無參數、不觸碰記憶體的簡單 syscall wrapper，
+    // 只在 `pre_exec` 的 fork 後子行程情境呼叫，符合它 async-signal-safe
+    // 的要求。
+    unsafe { setsid() }
+}
 
 const USER_COMMAND_MARKER_PREFIX: &str = "{{";
 const USER_COMMAND_TARGET_HASH_MARKER: &str = "{{target_hash}}";
@@ -295,29 +314,296 @@ fn build_user_command(params: &ExternalCommandParameters) -> Vec<String> {
     command
 }
 
-fn replace_command_arg(s: &str, params: &ExternalCommandParameters) -> String {
-    let sep = " ";
-    let target_hash = params.target_hash;
-    let first_parent_hash = &params.parent_hashes.first().cloned().unwrap_or_default();
-    let parent_hashes = &params.parent_hashes.join(sep);
-    let all_refs = &params.all_refs.join(sep);
-    let branches = &params.branches.join(sep);
-    let remote_branches = &params.remote_branches.join(sep);
-    let tags = &params.tags.join(sep);
-    let stash = params.stash.unwrap_or_default();
-    let area_width = &params.area_width.to_string();
-    let area_height = &params.area_height.to_string();
+/// 需要選到真正 commit 才有值的 marker——Working changes（virtual row）
+/// 沒有這些，字串裡含其中之一而 `params` 是 `None` 就該報錯，不能靜默展開
+/// 成空字串（`git show {{target_hash}}` 會變成 `git show `，代入了使用者
+/// 沒選的內容）。`{{area_width}}`/`{{area_height}}` 不算，來自面板尺寸，
+/// 跟有沒有選到 commit 無關，見 `replace_markers` 最後兩行。
+const COMMIT_MARKERS: &[&str] = &[
+    USER_COMMAND_TARGET_HASH_MARKER,
+    USER_COMMAND_FIRST_PARENT_HASH_MARKER,
+    USER_COMMAND_PARENT_HASHES_MARKER,
+    USER_COMMAND_REFS_MARKER,
+    USER_COMMAND_BRANCHES_MARKER,
+    USER_COMMAND_REMOTE_BRANCHES_MARKER,
+    USER_COMMAND_TAGS_MARKER,
+    USER_COMMAND_STASH_MARKER,
+];
 
-    s.replace(USER_COMMAND_TARGET_HASH_MARKER, target_hash)
-        .replace(USER_COMMAND_FIRST_PARENT_HASH_MARKER, first_parent_hash)
-        .replace(USER_COMMAND_PARENT_HASHES_MARKER, parent_hashes)
-        .replace(USER_COMMAND_REFS_MARKER, all_refs)
-        .replace(USER_COMMAND_BRANCHES_MARKER, branches)
-        .replace(USER_COMMAND_REMOTE_BRANCHES_MARKER, remote_branches)
-        .replace(USER_COMMAND_TAGS_MARKER, tags)
-        .replace(USER_COMMAND_STASH_MARKER, stash)
-        .replace(USER_COMMAND_AREA_WIDTH_MARKER, area_width)
-        .replace(USER_COMMAND_AREA_HEIGHT_MARKER, area_height)
+/// `marker` 必須是 `COMMIT_MARKERS` 裡的一個，否則 panic——呼叫端已經用
+/// `COMMIT_MARKERS` 篩過，這裡拿不到值代表兩份表對不上，是程式錯誤。
+/// `Single(v)` 等價於單元素的 `join`，不需要一個 enum 描述這兩種形狀。
+fn commit_marker_value(
+    marker: &str,
+    params: &ExternalCommandParameters,
+    esc: &impl Fn(&str) -> Result<String, String>,
+) -> Result<String, String> {
+    let join = |vs: &[&str]| -> Result<String, String> {
+        Ok(vs
+            .iter()
+            .copied()
+            .map(esc)
+            .collect::<Result<Vec<_>, _>>()?
+            .join(" "))
+    };
+    match marker {
+        USER_COMMAND_TARGET_HASH_MARKER => esc(params.target_hash),
+        USER_COMMAND_FIRST_PARENT_HASH_MARKER => {
+            esc(params.parent_hashes.first().copied().unwrap_or(""))
+        }
+        USER_COMMAND_PARENT_HASHES_MARKER => join(&params.parent_hashes),
+        USER_COMMAND_REFS_MARKER => join(&params.all_refs),
+        USER_COMMAND_BRANCHES_MARKER => join(&params.branches),
+        USER_COMMAND_REMOTE_BRANCHES_MARKER => join(&params.remote_branches),
+        USER_COMMAND_TAGS_MARKER => join(&params.tags),
+        USER_COMMAND_STASH_MARKER => esc(params.stash.unwrap_or("")),
+        _ => unreachable!("{marker} 不在 COMMIT_MARKERS 裡"),
+    }
+}
+
+/// 把 `s` 裡的 `{{marker}}` 換成值——`replace_command_arg`（逐字元代入，給
+/// argv 元素用）與 `expand_shell_command_line`（shell quote 後代入，給整段
+/// shell 指令字串用）共用同一份 marker 表，差異只在 `esc`。
+///
+/// 只在字串真的含某個 marker 時才求值／轉義：`{{stash}}` 不出現在指令裡
+/// 就不用管有沒有選到 stash，`params` 是 `None`（Working changes 列）時
+/// 也一樣——真正該報錯的只有「字串含 commit marker 但沒有 commit 可代」。
+///
+/// `esc` 回傳 `Result` 是為了 Windows shell quoting：某些字元在 `cmd /C`
+/// 底下沒有安全的轉義方式，那條路要能回傳 `Err` 而不是悄悄產出壞字串。
+/// `replace_command_arg` 用的 identity esc 永遠不會走到 `Err` 分支。
+fn replace_markers(
+    s: &str,
+    params: Option<&ExternalCommandParameters>,
+    area_width: u16,
+    area_height: u16,
+    esc: impl Fn(&str) -> Result<String, String>,
+) -> Result<String, String> {
+    let mut result = s.to_string();
+
+    for &marker in COMMIT_MARKERS {
+        if !result.contains(marker) {
+            continue;
+        }
+        let Some(params) = params else {
+            return Err(format!("沒有選到 commit，無法代入 {marker}"));
+        };
+        let value = commit_marker_value(marker, params, &esc)?;
+        result = result.replace(marker, &value);
+    }
+
+    if result.contains(USER_COMMAND_AREA_WIDTH_MARKER) {
+        result = result.replace(USER_COMMAND_AREA_WIDTH_MARKER, &area_width.to_string());
+    }
+    if result.contains(USER_COMMAND_AREA_HEIGHT_MARKER) {
+        result = result.replace(USER_COMMAND_AREA_HEIGHT_MARKER, &area_height.to_string());
+    }
+
+    Ok(result)
+}
+
+fn replace_command_arg(s: &str, params: &ExternalCommandParameters) -> String {
+    replace_markers(
+        s,
+        Some(params),
+        params.area_width,
+        params.area_height,
+        |v| Ok(v.to_string()),
+    )
+    .expect("完整 params + identity esc 永遠不會回 Err")
+}
+
+/// POSIX：任何值都能安全地用單引號包起來，內部單引號轉成 `'\''`
+/// （先結束引號、插入一個跳脫過的單引號、再開新引號）。
+#[cfg(not(target_os = "windows"))]
+fn shell_quote(v: &str) -> Result<String, String> {
+    Ok(format!("'{}'", v.replace('\'', r"'\''")))
+}
+
+/// Windows：`cmd /C` 沒有跟 POSIX 單引號等價的萬用轉義規則，含這些字元
+/// 的值直接報錯，不要靜靜產出可能被 cmd 另行解釋的字串。沒有特殊字元時
+/// 才需要引號的話就加雙引號；純字母數字原樣返回。
+#[cfg(target_os = "windows")]
+fn shell_quote(v: &str) -> Result<String, String> {
+    const DANGEROUS: &[char] = &['"', '%', '^', '&', '|', '<', '>'];
+    if v.chars().any(|c| DANGEROUS.contains(&c)) {
+        return Err(format!(
+            "無法在 Windows 上安全代入含 {DANGEROUS:?} 的值：{v:?}"
+        ));
+    }
+    if v.contains(char::is_whitespace) {
+        Ok(format!("\"{v}\""))
+    } else {
+        Ok(v.to_string())
+    }
+}
+
+/// 把使用者在命令列輸入的整段字串裡的 marker 換成目前選取 commit 的值，
+/// 每個值各自 shell-quote 後再代入——`{{branches}}` 展開成 `'main' 'dev'`
+/// 仍是兩個獨立參數，且 ref 名稱裡的單引號不會逃逸出去執行別的指令。
+///
+/// `params` 是 `None`：目前選取的是 Working changes（virtual row），沒有
+/// 真正的 commit。`{{area_width}}`/`{{area_height}}` 這兩個不吃 `params`，
+/// 一樣可以代入；含其餘 commit marker 就回 `Err`。
+///
+/// **巢狀 quote 無解**：marker 自己已經帶引號，使用者不該再手動包一層
+/// （`--grep="{{target_hash}}"` 會展開成 `--grep="'abc'"`，單引號變字面值）。
+pub fn expand_shell_command_line(
+    command_line: &str,
+    params: Option<&ExternalCommandParameters>,
+    area_width: u16,
+    area_height: u16,
+) -> Result<String, String> {
+    replace_markers(command_line, params, area_width, area_height, shell_quote)
+}
+
+/// POSIX shell 的 basename allowlist——決定 `exec_shell_command` 要不要加
+/// `-i`（讀 rc 檔的 alias／function）、要不要用 `exec 2>&1; ` 把 rc 初始化
+/// 噪音濾掉。用 basename 比對，不管呼叫端給的是完整路徑（`/bin/zsh`）還是
+/// 裸命令（`zsh`）；不在表內的（fish、nushell、Windows 的 `cmd`、使用者
+/// 自訂的怪 shell）一律當非 POSIX 處理，不冒然加只有這幾種 shell 才認得
+/// 的旗標／語法。
+pub(crate) fn is_posix_shell(prog: &str) -> bool {
+    const POSIX_SHELLS: &[&str] = &["sh", "bash", "zsh", "dash", "ksh", "mksh", "ash"];
+    let basename = std::path::Path::new(prog)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(prog);
+    POSIX_SHELLS.contains(&basename)
+}
+
+/// 讀取階段的記憶體上限——`yes`、`find /` 這類指令的輸出可以無限長，
+/// 這裡是真正接住的防線（不是事後對已經讀進記憶體的字串 truncate）。
+const MAX_OUTPUT_BYTES: usize = 5 * 1024 * 1024;
+
+/// 讀 `reader` 直到 EOF 或 `cap` bytes，回傳 `(內容, 是否被截斷)`。多讀
+/// 一個 byte 來判斷「剛好等於 cap」跟「超過 cap」的差別，超過時把多讀的
+/// 那個 byte 丟掉。
+fn read_capped(reader: &mut impl Read, cap: usize) -> (Vec<u8>, bool) {
+    let mut buf = Vec::new();
+    let _ = reader.take(cap as u64 + 1).read_to_end(&mut buf);
+    let truncated = buf.len() > cap;
+    if truncated {
+        buf.truncate(cap);
+    }
+    (buf, truncated)
+}
+
+/// 在 `repo_path` 底下經由 `shell` 執行 `command_line`，回傳合併後的
+/// stdout+stderr——非零 exit 一樣回傳輸出（附一行狀態），不當成 `Err`：
+/// 命令本身的錯誤訊息就是使用者要看的東西。`Err` 只保留給「連 shell 都
+/// 沒能啟動」這種真正例外的情況。
+///
+/// `shell` 是 `[程式, 旗標...]`（例如 `["zsh", "-i", "-c"]`），`command_line`
+/// 會當成最後一個引數接在後面——來源見 `app::resolve_shell_command` 或
+/// `core.shell.command` 設定。
+///
+/// POSIX shell（`is_posix_shell`）額外做兩件事：
+/// - 指令前面接 `exec 2>&1; `，把 shell 自己 rc 初始化階段的 stderr 噪音
+///   （例如 oh-my-zsh／powerlevel10k 的警告）留在 `exec` 之前、隨
+///   `stderr(Stdio::null())` 丟棄；`exec` 之後使用者指令的 stderr 併入
+///   stdout pipe，兩者交錯順序也因此是對的（不會像「stdout 全部接在前面 +
+///   stderr 全部接在後面」那樣把 `git fetch` 的進度整團排到最後）。
+/// - 帶 `SERIE_SHELL=1` 環境變數，讓使用者可以在 rc 檔開頭偵測它、
+///   early return 跳過主題／外掛，把每次執行都要付的 shell 初始化成本
+///   從約 1 秒降到接近 0（見 `docs/src/configurations/config-file-format.md`
+///   的 `[core.shell]` 說明）。
+///
+/// `child_slot`：spawn 出來的 child 會先存進這裡再開始讀——讓
+/// `ShellView` 能在使用者中途關閉（Esc）或整個 app 結束時砍掉還在跑的
+/// 指令（見 `view::shell::ShellView` 的 `Drop`），不留孤兒程序握著 pipe。
+pub fn exec_shell_command(
+    command_line: &str,
+    repo_path: &std::path::Path,
+    shell: &[String],
+    child_slot: &Arc<Mutex<Option<std::process::Child>>>,
+) -> Result<String, String> {
+    let Some((prog, flags)) = shell.split_first() else {
+        return Err("core.shell.command 不能是空陣列".to_string());
+    };
+    let posix = is_posix_shell(prog);
+    let full_command = if posix {
+        format!("exec 2>&1; {command_line}")
+    } else {
+        command_line.to_string()
+    };
+
+    let mut cmd = Command::new(prog);
+    cmd.args(flags)
+        .arg(&full_command)
+        .current_dir(repo_path)
+        .env("SERIE_SHELL", "1")
+        // 指令不該能讀鍵盤——`Stdio::null()` 是承重牆，不要為了互動指令拿掉。
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(if posix {
+            std::process::Stdio::null()
+        } else {
+            std::process::Stdio::piped()
+        });
+
+    // zsh 帶 `-i` 的 job control 初始化會經由 `/dev/tty`（不是繼承的 fd 0，
+    // 那個是 `/dev/tty` 永遠解析到的「目前這個 session 的控制終端機」，跟
+    // fd 0 有沒有被 redirect 無關）去搶 serie 自己的控制終端機。實測：不
+    // detach 的話，即使 zsh 印出「can't change option: monitor」放棄
+    // monitor mode，它中途仍可能已經 `tcsetpgrp` 過一次——這裡把它
+    // SIGKILL 掉（`ShellView::Drop`）時它來不及還原，serie 自己讀鍵盤的
+    // thread 就此讀不到終端輸入，`event::EventController` 的 watchdog 偵測
+    // 到停滯後會在約 2 秒內把整個 app 關掉（`AppEvent::Quit` 的
+    // watchdog fallback）。`setsid()` 讓子 process 進到一個全新、沒有控制
+    // 終端機的 session——`/dev/tty` 直接打不開，job control 初始化在
+    // *更早* 的地方就會安分失敗，不會碰到 serie 的終端。
+    #[cfg(unix)]
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc_setsid() < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to run {prog}: {e}"))?;
+    let mut stdout = child.stdout.take().expect("stdout is piped");
+    let mut stderr = child.stderr.take();
+
+    *child_slot.lock().unwrap() = Some(child);
+
+    let (out_buf, out_truncated) = read_capped(&mut stdout, MAX_OUTPUT_BYTES);
+    let mut text = String::from_utf8_lossy(&out_buf).into_owned();
+
+    let mut truncated = out_truncated;
+    if let Some(stderr) = stderr.as_mut() {
+        let (err_buf, err_truncated) = read_capped(stderr, MAX_OUTPUT_BYTES);
+        text.push_str(&String::from_utf8_lossy(&err_buf));
+        truncated |= err_truncated;
+    }
+
+    if truncated {
+        // 讀滿上限就砍掉 child——不然背景 job（`cmd &`）或 `yes` 這類
+        // 持續輸出的指令會讓這條 thread 一直卡在後續的 `wait()`。
+        if let Some(child) = child_slot.lock().unwrap().as_mut() {
+            let _ = child.kill();
+        }
+        text.push_str(&format!("\n… 輸出過長，已在 {MAX_OUTPUT_BYTES} bytes 截斷"));
+    }
+
+    // 先把 child 從鎖裡取出來再 wait——`child_slot.lock().unwrap().as_mut()`
+    // 這種寫法的暫存 `MutexGuard` 活到整個語句結束，會讓 `wait()` 全程握著
+    // 鎖：使用者這時按 Esc，主執行緒 `ShellView::Drop` 的 `self.child.lock()`
+    // 就會被卡住（指令背景化、關掉 stdout 但自己還沒結束時最容易踩到）。
+    // 拆成兩個語句，鎖在 `.take()` 那行結束就放掉，`wait()` 操作的是已經
+    // 拿出來的本地變數，不再需要鎖。
+    let child = child_slot.lock().unwrap().take();
+    let status = child.and_then(|mut c| c.wait().ok());
+    if let Some(status) = status {
+        if !status.success() {
+            text.push_str(&format!("\n[exit status: {status}]"));
+        }
+    }
+    Ok(text)
 }
 
 #[cfg(test)]
@@ -398,5 +684,168 @@ mod tests {
         let command = ["echo".to_string(), "[{{stash}}]".to_string()];
         let params = params_with_stash(&command, None);
         assert_eq!(build_user_command(&params), vec!["echo", "[]"]);
+    }
+
+    /// `replace_command_arg` 的 identity esc 不該轉義任何東西——argv 元素
+    /// 直接傳給 `Command::args()`，不經過 shell，加引號反而是錯的。
+    #[test]
+    fn replace_command_arg_identity_esc_does_not_quote() {
+        let command: [String; 0] = [];
+        let params = ExternalCommandParameters {
+            command: &command,
+            target_hash: "abc123",
+            parent_hashes: vec![],
+            all_refs: vec![],
+            branches: vec!["it's-a-branch"],
+            remote_branches: vec![],
+            tags: vec![],
+            stash: None,
+            area_width: 80,
+            area_height: 30,
+        };
+        assert_eq!(
+            replace_command_arg("{{target_hash}} {{branches}}", &params),
+            "abc123 it's-a-branch"
+        );
+    }
+
+    #[test]
+    fn expand_shell_command_line_quotes_each_branch_separately() {
+        let command: [String; 0] = [];
+        let params = ExternalCommandParameters {
+            command: &command,
+            target_hash: "abc123",
+            parent_hashes: vec![],
+            all_refs: vec![],
+            branches: vec!["main", "dev"],
+            remote_branches: vec![],
+            tags: vec![],
+            stash: None,
+            area_width: 80,
+            area_height: 30,
+        };
+        let expanded =
+            expand_shell_command_line("git log {{branches}}", Some(&params), 80, 30).unwrap();
+        assert_eq!(expanded, "git log 'main' 'dev'");
+    }
+
+    #[test]
+    fn expand_shell_command_line_escapes_single_quote_in_value() {
+        let command: [String; 0] = [];
+        let params = ExternalCommandParameters {
+            command: &command,
+            target_hash: "abc123",
+            parent_hashes: vec![],
+            all_refs: vec![],
+            branches: vec!["it's-a-branch"],
+            remote_branches: vec![],
+            tags: vec![],
+            stash: None,
+            area_width: 80,
+            area_height: 30,
+        };
+        // ref 名稱含單引號時，展開後仍是安全的單一 shell token——
+        // 不會逃逸出去變成「執行別的指令」。
+        let expanded =
+            expand_shell_command_line("git log {{branches}}", Some(&params), 80, 30).unwrap();
+        assert_eq!(expanded, r"git log 'it'\''s-a-branch'");
+    }
+
+    #[test]
+    fn expand_shell_command_line_interpolates_target_hash_mid_string() {
+        let command: [String; 0] = [];
+        let params = ExternalCommandParameters {
+            command: &command,
+            target_hash: "deadbeef",
+            parent_hashes: vec![],
+            all_refs: vec![],
+            branches: vec![],
+            remote_branches: vec![],
+            tags: vec![],
+            stash: None,
+            area_width: 80,
+            area_height: 30,
+        };
+        let expanded =
+            expand_shell_command_line("git log --grep={{target_hash}} -1", Some(&params), 80, 30)
+                .unwrap();
+        assert_eq!(expanded, "git log --grep='deadbeef' -1");
+    }
+
+    #[test]
+    fn expand_shell_command_line_without_commit_errors_on_commit_marker() {
+        // Working changes 列（virtual row）沒有真正的 commit——`params`
+        // 傳 `None`，錯誤訊息要點名是哪一個 marker，不能靜默展開成空字串。
+        let err = expand_shell_command_line("git show {{target_hash}}", None, 80, 30).unwrap_err();
+        assert!(
+            err.contains("{{target_hash}}"),
+            "錯誤訊息要點名 marker: {err}"
+        );
+    }
+
+    #[test]
+    fn expand_shell_command_line_without_commit_allows_area_markers() {
+        // {{area_width}}/{{area_height}} 來自面板尺寸，跟有沒有選到 commit
+        // 無關，Working changes 列一樣要能用。
+        let expanded =
+            expand_shell_command_line("echo {{area_width}}x{{area_height}}", None, 120, 40)
+                .unwrap();
+        assert_eq!(expanded, "echo 120x40");
+    }
+
+    #[test]
+    fn expand_shell_command_line_without_commit_passes_through_when_no_marker() {
+        // 沒有 marker 的指令（`git status` 這類）在 Working changes 列
+        // 要能原樣執行，不該因為沒有 commit 就被擋下。
+        let expanded = expand_shell_command_line("git status", None, 80, 30).unwrap();
+        assert_eq!(expanded, "git status");
+    }
+
+    #[test]
+    fn is_posix_shell_matches_by_basename() {
+        assert!(is_posix_shell("zsh"));
+        assert!(is_posix_shell("/bin/zsh"));
+        assert!(is_posix_shell("/usr/local/bin/bash"));
+        assert!(!is_posix_shell("fish"));
+        assert!(!is_posix_shell("cmd"));
+        assert!(!is_posix_shell(""));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn exec_shell_command_merges_stdout_and_stderr_in_order() {
+        // POSIX 路徑：`exec 2>&1; ` 讓兩個串流併成一個 pipe，順序要跟
+        // 指令本身寫的順序一致，不是「stdout 全部 + stderr 全部」。
+        let shell = vec!["sh".to_string(), "-c".to_string()];
+        let child_slot = Arc::new(Mutex::new(None));
+        let output = exec_shell_command(
+            "echo out1; echo err1 >&2; echo out2",
+            &env::temp_dir(),
+            &shell,
+            &child_slot,
+        )
+        .unwrap();
+        assert_eq!(output.trim_end(), "out1\nerr1\nout2");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn exec_shell_command_appends_exit_status_on_failure() {
+        let shell = vec!["sh".to_string(), "-c".to_string()];
+        let child_slot = Arc::new(Mutex::new(None));
+        let output = exec_shell_command("exit 3", &env::temp_dir(), &shell, &child_slot).unwrap();
+        assert!(
+            output.contains("[exit status:"),
+            "非零 exit 要附上狀態: {output}"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn shell_quote_rejects_dangerous_characters_on_windows() {
+        assert!(shell_quote("safe-value").is_ok());
+        assert!(shell_quote("has space").unwrap().starts_with('"'));
+        assert!(shell_quote("dangerous & value").is_err());
+        assert!(shell_quote("quoted\"value").is_err());
     }
 }

--- a/src/external.rs
+++ b/src/external.rs
@@ -5,6 +5,7 @@ use std::{
     io::{self, Read, Write},
     process::Command,
     sync::{Arc, Mutex},
+    thread,
 };
 
 use arboard::Clipboard;
@@ -425,7 +426,7 @@ fn shell_quote(v: &str) -> Result<String, String> {
 /// 才需要引號的話就加雙引號；純字母數字原樣返回。
 #[cfg(target_os = "windows")]
 fn shell_quote(v: &str) -> Result<String, String> {
-    const DANGEROUS: &[char] = &['"', '%', '^', '&', '|', '<', '>'];
+    const DANGEROUS: &[char] = &['"', '%', '^', '&', '|', '<', '>', '(', ')', '!'];
     if v.chars().any(|c| DANGEROUS.contains(&c)) {
         return Err(format!(
             "無法在 Windows 上安全代入含 {DANGEROUS:?} 的值：{v:?}"
@@ -567,23 +568,39 @@ pub fn exec_shell_command(
         .spawn()
         .map_err(|e| format!("Failed to run {prog}: {e}"))?;
     let mut stdout = child.stdout.take().expect("stdout is piped");
-    let mut stderr = child.stderr.take();
+    let stderr = child.stderr.take();
 
     *child_slot.lock().unwrap() = Some(child);
+
+    // 非 POSIX shell 路徑（Windows 的 `cmd /C`、fish、nushell……）stdout／
+    // stderr 各自獨立 pipe，依序讀會死鎖：子行程寫滿其中一邊的 OS pipe
+    // buffer 後卡住等讀者，這條 thread 卻還卡在讀另一邊——兩邊互等，直到
+    // 使用者手動關閉 shell 才會被砍掉。開一條 thread 併行讀 stderr，跟
+    // stdout 在目前這條 thread 同時進行，就不會有誰等誰的問題。
+    let stderr_thread =
+        stderr.map(|mut stderr| thread::spawn(move || read_capped(&mut stderr, MAX_OUTPUT_BYTES)));
 
     let (out_buf, out_truncated) = read_capped(&mut stdout, MAX_OUTPUT_BYTES);
     let mut text = String::from_utf8_lossy(&out_buf).into_owned();
 
-    let mut truncated = out_truncated;
-    if let Some(stderr) = stderr.as_mut() {
-        let (err_buf, err_truncated) = read_capped(stderr, MAX_OUTPUT_BYTES);
-        text.push_str(&String::from_utf8_lossy(&err_buf));
-        truncated |= err_truncated;
+    // stdout 讀滿上限代表不會再讀了——child 若還在寫 stdout（pipe 滿）會
+    // 卡住，不再往 stderr 寫也不會結束，下面 join stderr thread 就永遠
+    // 等不到 EOF。這裡先砍掉 child 讓它解套，join 才回得來。
+    if out_truncated {
+        if let Some(child) = child_slot.lock().unwrap().as_mut() {
+            let _ = child.kill();
+        }
     }
 
+    let (err_buf, err_truncated) = stderr_thread
+        .and_then(|t| t.join().ok())
+        .unwrap_or_default();
+    text.push_str(&String::from_utf8_lossy(&err_buf));
+
+    let truncated = out_truncated || err_truncated;
     if truncated {
-        // 讀滿上限就砍掉 child——不然背景 job（`cmd &`）或 `yes` 這類
-        // 持續輸出的指令會讓這條 thread 一直卡在後續的 `wait()`。
+        // child 可能還沒被上面那次 kill 砍到（例如只有 stderr 端截斷）——
+        // 對已經死掉的 child 再 kill 一次是無害的 no-op。
         if let Some(child) = child_slot.lock().unwrap().as_mut() {
             let _ = child.kill();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,6 +503,9 @@ pub fn run() -> Result<()> {
         }
     }
 
+    let shell_command =
+        app::resolve_shell_command(&core_config.shell, std::env::var("SHELL").ok().as_deref());
+
     let ctx = Rc::new(app::AppContext {
         keybind,
         core_config,
@@ -512,6 +515,7 @@ pub fn run() -> Result<()> {
         graph_width,
         compact,
         update: update_settings,
+        shell_command,
     });
 
     let mut ec = event::EventController::init();

--- a/src/view.rs
+++ b/src/view.rs
@@ -10,6 +10,7 @@ mod list;
 mod markdown;
 mod refs;
 mod release_notes;
+pub(crate) mod shell;
 pub(crate) mod user_command;
 
 pub use refs::RefsOrigin;

--- a/src/view/detail.rs
+++ b/src/view/detail.rs
@@ -310,6 +310,9 @@ impl<'a> DetailView<'a> {
             UserEvent::RefList => {
                 self.tx.send(AppEvent::OpenRefs);
             }
+            UserEvent::ShellToggle => {
+                self.tx.send(AppEvent::OpenShell);
+            }
             UserEvent::Refresh => {
                 self.refresh();
             }

--- a/src/view/help.rs
+++ b/src/view/help.rs
@@ -55,6 +55,7 @@ enum HelpBlock {
     DeleteTag,
     DeleteRef,
     UserCommand,
+    Shell,
     ReleaseNotes,
 }
 
@@ -71,6 +72,7 @@ impl HelpBlock {
             HelpBlock::DeleteTag => "Delete Tag",
             HelpBlock::DeleteRef => "Delete Ref",
             HelpBlock::UserCommand => "User Command",
+            HelpBlock::Shell => "Shell 命令列",
             HelpBlock::ReleaseNotes => "Release Notes",
         }
     }
@@ -96,6 +98,7 @@ impl HelpBlock {
             HelpBlock::DeleteTag => &["src/view/delete_tag.rs"],
             HelpBlock::DeleteRef => &["src/view/delete_ref.rs"],
             HelpBlock::UserCommand => &["src/view/user_command.rs"],
+            HelpBlock::Shell => &["src/view/shell.rs"],
             HelpBlock::ReleaseNotes => &["src/view/release_notes.rs"],
         }
     }
@@ -307,6 +310,7 @@ fn help_blocks(
         b(vec![UserEvent::Fetch],                                 "fetch 所有 remote",   "Fetch all remotes"),
         b(vec![UserEvent::Checkout],                              "checkout 選取的 commit/ref", "Checkout selected commit/ref"),
         b(vec![UserEvent::Refresh],                               "重新整理",            "Refresh"),
+        b(vec![UserEvent::ShellToggle],                           "開啟命令列",          "Open shell"),
     ];
 
     let detail = vec![
@@ -337,6 +341,7 @@ fn help_blocks(
         b(vec![UserEvent::GitHubToggle],                                 "開啟 GitHub issues/PRs", "Open GitHub issues/PRs"),
         b(vec![UserEvent::HelpToggle],                                   "開啟說明",          "Open help"),
         b(vec![UserEvent::Refresh],                                      "重新整理",          "Refresh"),
+        b(vec![UserEvent::ShellToggle],                                  "開啟命令列",        "Open shell"),
     ];
 
     let refs = vec![
@@ -416,6 +421,11 @@ fn help_blocks(
     list.extend(user_command_items.iter().cloned());
     user_command.extend(user_command_items);
 
+    let shell = vec![
+        b(vec![UserEvent::Confirm], "執行指令",   "Run command"),
+        b(vec![UserEvent::Cancel],  "關閉命令列", "Close shell"),
+    ];
+
     let release_notes = vec![
         b(vec![UserEvent::Quit], "離開（按兩下）", "Quit (press twice)"),
         b(vec![UserEvent::Cancel, UserEvent::Close, UserEvent::NavigateLeft],
@@ -439,6 +449,7 @@ fn help_blocks(
         (HelpBlock::DeleteTag,    delete_tag),
         (HelpBlock::DeleteRef,    delete_ref),
         (HelpBlock::UserCommand,  user_command),
+        (HelpBlock::Shell,        shell),
         (HelpBlock::ReleaseNotes, release_notes),
     ]
 }
@@ -704,6 +715,8 @@ mod tests {
 | <kbd>f</kbd> | 刪除 branch 確認 | 強制刪除 |
 | <kbd>Tab</kbd> <kbd>Shift-Tab</kbd> | Create tag 對話框 | 在欄位間移動 |
 | <kbd>Space</kbd> | Create tag 對話框（核取方塊） | 切換核取狀態 |
+| <kbd>↑</kbd> <kbd>↓</kbd> | Shell 命令列 | 瀏覽指令歷史 |
+| <kbd>PageUp</kbd> <kbd>PageDown</kbd> | Shell 命令列 | 捲動輸出面板 |
 ";
 
     fn render_doc(keybind: &KeyBind, core_config: &CoreConfig) -> String {

--- a/src/view/list.rs
+++ b/src/view/list.rs
@@ -170,6 +170,9 @@ impl<'a> ListView<'a> {
             UserEvent::RefList => {
                 self.tx.send(AppEvent::OpenRefs);
             }
+            UserEvent::ShellToggle => {
+                self.tx.send(AppEvent::OpenShell);
+            }
             UserEvent::CreateTag => {
                 self.tx.send(AppEvent::OpenCreateTag);
             }

--- a/src/view/shell.rs
+++ b/src/view/shell.rs
@@ -270,6 +270,13 @@ impl<'a> ShellView<'a> {
             return;
         }
 
+        // 輸出面板從無到有才要清：不論等下執行成功或參數展開失敗顯示錯誤，
+        // before_area（含圖表）都會被壓縮，不清會留殘影（跟 `app::open_shell`
+        // 第一次壓縮同一個道理）；面板已經開著時版面不變，不必再清一次。
+        if self.output_lines.is_empty() {
+            self.request_graph_clear();
+        }
+
         let params = self.commit.as_ref().map(|commit| {
             external_command_parameters(&[], commit, &self.refs, self.area_width, self.area_height)
         });

--- a/src/view/shell.rs
+++ b/src/view/shell.rs
@@ -1,0 +1,405 @@
+use std::{
+    path::PathBuf,
+    process::Child,
+    rc::Rc,
+    sync::{mpsc, Arc, Mutex},
+    thread,
+};
+
+use ratatui::{
+    crossterm::event::{KeyCode, KeyEvent, KeyEventKind},
+    layout::{Constraint, Layout, Rect},
+    style::Style,
+    text::{Line, Span},
+    widgets::{Block, Borders, Padding, Paragraph},
+    Frame,
+};
+use tui_input::{backend::crossterm::EventHandler, Input};
+
+use crate::{
+    app::{external_command_parameters, AppContext},
+    config::CursorType,
+    event::{AppEvent, Sender, UserEvent, UserEventWithCount},
+    external::{exec_shell_command, expand_shell_command_line},
+    git::{Commit, Ref},
+    view::{ansi_output_to_lines, View},
+    widget::{
+        output_pane::{OutputPane, OutputPaneState},
+        split_at_width,
+    },
+};
+
+/// 輸出面板固定高度——沒有開 `ui.pane_height.shell` 設定，這是沒人要求過
+/// 的旋鈕，有人抱怨再加。
+pub(crate) const OUTPUT_PANE_HEIGHT: u16 = 20;
+
+/// 顯示層的行數上限——記憶體層的上限是 `external::MAX_OUTPUT_BYTES`
+/// （讀取階段就接住，不是等字串已經進了記憶體才 truncate）；這裡單純是
+/// 避免幾萬行塞進 `OutputPane` 拖慢渲染。
+const MAX_OUTPUT_LINES: usize = 50_000;
+
+/// `render()` 與 `{{area_height}}` marker 的面積算式共用同一個來源——分開寫
+/// 兩份曾經漂移過（marker 那份忘了扣輸入列吃掉的那一行，短終端下算多 1）。
+/// 回傳的是輸出面板的 *外框* 高度；扣掉 `OutputPane` 自己的上邊框才是內容
+/// 可用列數，呼叫端各自處理（`render()` 把它原樣交給 widget，widget 內部
+/// 自己扣；marker 算式要自己扣一次）。
+///
+/// 這兩個數字是開啟命令列當下算好、存進 `ShellView` 的快照——終端機
+/// resize 之後 `render()` 會用新的即時 `area`，但 `{{area_width}}`／
+/// `{{area_height}}` marker 展開用的還是開啟當下那份，會跟畫面顯示的
+/// 尺寸不同步。跟 user command 那條路徑一樣的取捨（`app::open_shell` /
+/// `app::build_external_command_parameters` 也是開啟當下算一次），不是
+/// 這裡才有的新問題。
+pub(crate) fn output_pane_height(area_height: u16) -> u16 {
+    OUTPUT_PANE_HEIGHT.min(area_height.saturating_sub(2))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShellAction {
+    Run,
+    Close,
+    HistPrev,
+    HistNext,
+    ScrollUp,
+    ScrollDown,
+    Text,
+}
+
+/// 預設鍵位把 `j k h l i m . q r c b v t d o g u f p x z y n` 幾乎整片
+/// 字母佔走了，命令列必須能完整打出 `git`、`branch`。只有 Up/Down/PageUp/
+/// PageDown 這四個是不可設定的原始鍵——因為 `j`/`k` 必須留給文字輸入，沒有
+/// `UserEvent` 可以綁。Confirm／Cancel 仍走可設定的 `UserEvent`，但要排除
+/// `y`/`n`：兩者的預設綁定含這兩個字元，比照 `CreateTagView` 讓它們在文字
+/// 欄位裡維持文字語意。
+fn resolve(event: UserEvent, key: KeyEvent) -> ShellAction {
+    match key.code {
+        KeyCode::Up => ShellAction::HistPrev,
+        KeyCode::Down => ShellAction::HistNext,
+        KeyCode::PageUp => ShellAction::ScrollUp,
+        KeyCode::PageDown => ShellAction::ScrollDown,
+        _ => match event {
+            UserEvent::Confirm if key.code != KeyCode::Char('y') => ShellAction::Run,
+            UserEvent::Cancel if key.code != KeyCode::Char('n') => ShellAction::Close,
+            _ => ShellAction::Text,
+        },
+    }
+}
+
+#[derive(Debug)]
+pub struct ShellView<'a> {
+    before: View<'a>,
+    /// `None` = 目前選取的是 Working changes（virtual row），沒有真正的
+    /// commit 可以代入 `{{target_hash}}` 系列 marker——`run()` 只在指令
+    /// 真的含這些 marker 時才報錯，不含（`git status` 這類）照跑。
+    commit: Option<Commit>,
+    refs: Vec<Ref>,
+    area_width: u16,
+    area_height: u16,
+    repo_path: PathBuf,
+
+    input: Input,
+    history: Vec<String>,
+    /// `None` = 目前在編輯新指令（不在瀏覽歷史）。
+    history_index: Option<usize>,
+
+    output_lines: Vec<Line<'static>>,
+    output_pane_state: OutputPaneState,
+    /// `Some` = 指令在背景執行緒跑，`try_recv` 拿得到結果就轉成 `None`。
+    /// 這個欄位本身就是「執行中」旗標，不需要額外的 generation 計數——
+    /// `ShellView` 被 drop（例如使用者中途按 Esc）時 `Receiver` 跟著被
+    /// drop，背景 thread 的 `send` 會回 `Err`，舊結果自動失去去處。
+    rx: Option<mpsc::Receiver<Vec<Line<'static>>>>,
+    /// 背景 thread 目前跑的 child process——`Drop` 用它在使用者中途關閉
+    /// （Esc）或整個 app 結束時砍掉還在跑的指令，不留孤兒程序握著 pipe
+    /// （`git push` 卡認證、寫錯的無窮迴圈都會走到這裡）。每次 `run()`
+    /// 重用同一個 `Arc`，不是每次重建——`rx.is_some()` 已經擋掉了重疊執行，
+    /// 同一時間至多一個 child。
+    child: Arc<Mutex<Option<Child>>>,
+    /// git watcher 觸發的 `AppEvent::Refresh` 若直接重建 `App`，`ShellView`
+    /// 會被整個炸掉（輸入、歷史、輸出全部消失）——這個功能的用途就是跑會
+    /// 改動 repo 的指令，watcher 一秒內就會觸發。所以 `refresh()` 只設這個
+    /// 旗標，實際刷新延後到 `close_shell` 還原 `before` 之後才補送。
+    refresh_pending: bool,
+
+    ctx: Rc<AppContext>,
+    tx: Sender,
+}
+
+impl<'a> ShellView<'a> {
+    pub fn new(
+        before: View<'a>,
+        commit: Option<Commit>,
+        refs: Vec<Ref>,
+        area_width: u16,
+        area_height: u16,
+        repo_path: PathBuf,
+        ctx: Rc<AppContext>,
+        tx: Sender,
+    ) -> ShellView<'a> {
+        ShellView {
+            before,
+            commit,
+            refs,
+            area_width,
+            area_height,
+            repo_path,
+            input: Input::default(),
+            history: Vec::new(),
+            history_index: None,
+            output_lines: Vec::new(),
+            output_pane_state: OutputPaneState::default(),
+            rx: None,
+            child: Arc::new(Mutex::new(None)),
+            refresh_pending: false,
+            ctx,
+            tx,
+        }
+    }
+
+    pub fn take_before_view(&mut self) -> View<'a> {
+        std::mem::take(&mut self.before)
+    }
+
+    /// 下面四個方法單純委派給 `before`——`ShellView::render` 畫的就是
+    /// `before`，跑馬燈與 graph clear 的旗標／狀態也活在它身上，見
+    /// `View::marquee_id` 等呼叫端的文件註解。
+    pub fn marquee_id(&self) -> Option<std::sync::Arc<str>> {
+        self.before.marquee_id()
+    }
+
+    pub fn marquee_needed(&self) -> bool {
+        self.before.marquee_needed()
+    }
+
+    pub fn take_graph_clear(&mut self) -> bool {
+        self.before.take_graph_clear()
+    }
+
+    pub fn request_graph_clear(&mut self) {
+        self.before.request_graph_clear();
+    }
+
+    /// `View::refresh()` 的 Shell arm 呼叫這裡——見上面 `refresh_pending`
+    /// 的註解，這裡只記旗標，不能真的動 `before`（那會把它跟 `Refresh`
+    /// event 的 `RefreshViewContext` 綁在一起，Shell 沒有對應的 context
+    /// 變體）。故意不叫 `refresh`：其他 view 的 `refresh()` 是「立刻送出
+    /// `AppEvent::Refresh`」，同名但語意不同容易混淆。
+    pub fn mark_refresh_pending(&mut self) {
+        self.refresh_pending = true;
+    }
+
+    pub fn take_refresh_pending(&mut self) -> bool {
+        std::mem::take(&mut self.refresh_pending)
+    }
+
+    /// `AppEvent::ShellOutputReady` 抵達時呼叫。過期的喚醒（例如指令還沒
+    /// 跑完使用者就關掉、又重開了一個新的 ShellView）打到新 view 的空
+    /// `rx`，`try_recv` 拿不到東西，什麼都不做——正確地什麼都不做。
+    pub fn poll_output(&mut self) {
+        let Some(rx) = &self.rx else { return };
+        match rx.try_recv() {
+            Ok(lines) => {
+                self.output_lines = lines;
+                self.output_pane_state = OutputPaneState::default();
+                self.rx = None;
+            }
+            Err(mpsc::TryRecvError::Empty) => {}
+            // 背景 thread panic 或提早結束、沒送出結果就掛了——沒有結果可
+            // 拿，但「執行中」這個狀態不能繼續卡著：不清掉的話 `run()`
+            // 會永遠在 `rx.is_some()` 那條早退，使用者只能關掉命令列重開。
+            Err(mpsc::TryRecvError::Disconnected) => {
+                self.rx = None;
+            }
+        }
+    }
+
+    pub fn handle_event(&mut self, event_with_count: UserEventWithCount, key: KeyEvent) {
+        // Windows 上釋放 key 也會送事件；不濾掉的話 Enter 一次按壓
+        // 會觸發兩次執行。
+        if key.kind != KeyEventKind::Press {
+            return;
+        }
+
+        match resolve(event_with_count.event, key) {
+            ShellAction::Run => self.run(),
+            ShellAction::Close => self.tx.send(AppEvent::CloseShell),
+            ShellAction::HistPrev => self.history_prev(),
+            ShellAction::HistNext => self.history_next(),
+            ShellAction::ScrollUp => self.output_pane_state.scroll_page_up(),
+            ShellAction::ScrollDown => self.output_pane_state.scroll_page_down(),
+            ShellAction::Text => {
+                self.input
+                    .handle_event(&ratatui::crossterm::event::Event::Key(key));
+            }
+        }
+    }
+
+    fn history_prev(&mut self) {
+        if self.history.is_empty() {
+            return;
+        }
+        let idx = match self.history_index {
+            None => self.history.len() - 1,
+            Some(i) => i.saturating_sub(1),
+        };
+        self.history_index = Some(idx);
+        self.input = Input::new(self.history[idx].clone());
+    }
+
+    fn history_next(&mut self) {
+        match self.history_index {
+            None => {}
+            Some(i) if i + 1 < self.history.len() => {
+                self.history_index = Some(i + 1);
+                self.input = Input::new(self.history[i + 1].clone());
+            }
+            Some(_) => {
+                self.history_index = None;
+                self.input.reset();
+            }
+        }
+    }
+
+    fn run(&mut self) {
+        // 執行中拒收新命令——`rx` 本身就是「執行中」旗標。
+        if self.rx.is_some() {
+            return;
+        }
+        let value = self.input.value().trim().to_string();
+        if value.is_empty() {
+            return;
+        }
+
+        let params = self.commit.as_ref().map(|commit| {
+            external_command_parameters(&[], commit, &self.refs, self.area_width, self.area_height)
+        });
+        let expanded = match expand_shell_command_line(
+            &value,
+            params.as_ref(),
+            self.area_width,
+            self.area_height,
+        ) {
+            Ok(s) => s,
+            Err(err) => {
+                self.output_lines = vec![Line::styled(
+                    err,
+                    Style::default().fg(self.ctx.color_theme.status_error_fg),
+                )];
+                self.output_pane_state = OutputPaneState::default();
+                return;
+            }
+        };
+
+        self.input.reset();
+        self.history.push(value);
+        self.history_index = None;
+
+        let (result_tx, result_rx) = mpsc::channel();
+        self.rx = Some(result_rx);
+
+        let repo_path = self.repo_path.clone();
+        let tab_width = self.ctx.core_config.user_command.tab_width;
+        let shell = self.ctx.shell_command.clone();
+        let child = self.child.clone();
+        let app_tx = self.tx.clone();
+        thread::spawn(move || {
+            let output =
+                exec_shell_command(&expanded, &repo_path, &shell, &child).unwrap_or_else(|e| e);
+            let mut lines =
+                ansi_output_to_lines(output, tab_width).unwrap_or_else(|e| vec![Line::raw(e)]);
+            if lines.len() > MAX_OUTPUT_LINES {
+                lines.truncate(MAX_OUTPUT_LINES);
+                lines.push(Line::raw(format!(
+                    "… 輸出過長，已截斷在 {MAX_OUTPUT_LINES} 行"
+                )));
+            }
+            // ShellView 若已經被關掉／換掉，這裡的 rx 早就 drop 了，
+            // send 會回 Err——靜靜丟棄過期結果就是正確行為。
+            let _ = result_tx.send(lines);
+            app_tx.send(AppEvent::ShellOutputReady);
+        });
+    }
+
+    pub fn render(&mut self, f: &mut Frame, area: Rect, marquee_frame: u64) {
+        let running = self.rx.is_some();
+        let show_output = running || !self.output_lines.is_empty();
+        let output_height = if show_output {
+            output_pane_height(area.height)
+        } else {
+            0
+        };
+
+        // Length(2)：一列 TOP 邊框當分隔線 + 一列輸入內容，跟 `status_line`
+        // 自己那一列（app.rs 的 `[Min(0), Length(2)]`）同一個形狀。
+        let [before_area, input_area, output_area] = Layout::vertical([
+            Constraint::Min(0),
+            Constraint::Length(2),
+            Constraint::Length(output_height),
+        ])
+        .areas(area);
+
+        self.before.render(f, before_area, marquee_frame);
+        self.render_input(f, input_area, running);
+
+        if show_output {
+            let output_pane = OutputPane::new(&self.output_lines, self.ctx.clone());
+            f.render_stateful_widget(output_pane, output_area, &mut self.output_pane_state);
+        }
+    }
+
+    fn render_input(&mut self, f: &mut Frame, area: Rect, running: bool) {
+        const PROMPT: &str = "$ ";
+        let block = Block::default()
+            .borders(Borders::TOP)
+            .style(Style::default().fg(self.ctx.color_theme.divider_fg))
+            .padding(Padding::horizontal(1));
+        let inner = block.inner(area);
+
+        let inner_width = inner.width.saturating_sub(PROMPT.len() as u16).max(1) as usize;
+        // `visual_scroll` 回傳的是顯示寬度（tui-input 用 UnicodeWidthChar 累加），
+        // 不是 byte offset——直接拿去切 `&value()[scroll..]` 在中文輸入下會切在
+        // char 中間、當場 panic。`split_at_width` 就是用同一套寬度計算找 char
+        // 邊界，兩者的 unit 對得上。
+        let scroll = self.input.visual_scroll(inner_width);
+        let (_, visible) = split_at_width(self.input.value(), scroll);
+
+        let mut spans = vec![Span::raw(PROMPT), Span::raw(visible)];
+        if running {
+            spans.push(Span::styled(
+                "  running…",
+                Style::default().fg(self.ctx.color_theme.status_input_transient_fg),
+            ));
+        }
+
+        let paragraph = Paragraph::new(Line::from(spans))
+            .style(Style::default().fg(self.ctx.color_theme.fg))
+            .block(block);
+        f.render_widget(paragraph, area);
+
+        if !running {
+            let x = inner.x + PROMPT.len() as u16 + (self.input.visual_cursor() - scroll) as u16;
+            let y = inner.y;
+            match &self.ctx.ui_config.cursor_type {
+                CursorType::Native => f.set_cursor_position((x, y)),
+                CursorType::Virtual(cursor) => {
+                    let style = Style::default().fg(self.ctx.color_theme.virtual_cursor_fg);
+                    f.buffer_mut().set_string(x, y, cursor, style);
+                }
+            }
+        }
+    }
+}
+
+impl Drop for ShellView<'_> {
+    /// 使用者按 Esc 關閉（`before` 被 `take_before_view` 取出後，`self.view`
+    /// 被換成別的 view，這個 `Box<ShellView>` 就掉了）或整個 App 結束時都
+    /// 會經過這裡——還在跑的指令（`git push` 卡認證、寫錯的無窮迴圈）不會
+    /// 變成孤兒程序繼續握著 pipe。
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.child.lock() {
+            if let Some(child) = guard.as_mut() {
+                let _ = child.kill();
+            }
+        }
+    }
+}

--- a/src/view/views.rs
+++ b/src/view/views.rs
@@ -9,7 +9,8 @@ use crate::{
     view::{
         create_tag::CreateTagView, delete_ref::DeleteRefView, delete_tag::DeleteTagView,
         detail::DetailView, github::GitHubView, help::HelpView, list::ListView, refs::RefsView,
-        release_notes::ReleaseNotesView, user_command::UserCommandView, RefsOrigin,
+        release_notes::ReleaseNotesView, shell::ShellView, user_command::UserCommandView,
+        RefsOrigin,
     },
     widget::{commit_list::CommitListState, ref_list::RefListState},
 };
@@ -28,6 +29,7 @@ pub enum View<'a> {
     Help(Box<HelpView<'a>>),
     GitHub(Box<GitHubView<'a>>),
     ReleaseNotes(Box<ReleaseNotesView<'a>>),
+    Shell(Box<ShellView<'a>>),
 }
 
 impl<'a> View<'a> {
@@ -44,6 +46,7 @@ impl<'a> View<'a> {
             View::Help(view) => view.handle_event(event_with_count, key_event),
             View::GitHub(view) => view.handle_event(event_with_count, key_event),
             View::ReleaseNotes(view) => view.handle_event(event_with_count, key_event),
+            View::Shell(view) => view.handle_event(event_with_count, key_event),
         }
     }
 
@@ -60,6 +63,7 @@ impl<'a> View<'a> {
             View::Help(view) => view.render(f, area),
             View::GitHub(view) => view.render(f, area, marquee_frame),
             View::ReleaseNotes(view) => view.render(f, area),
+            View::Shell(view) => view.render(f, area, marquee_frame),
         }
     }
 
@@ -70,6 +74,10 @@ impl<'a> View<'a> {
             View::List(view) => Some(view.as_list_state().selected_commit_hash().as_arc()),
             View::Detail(view) => view.marquee_id(),
             View::GitHub(view) => view.marquee_id(),
+            // `ShellView::render` 畫的是 `before`——不委派的話跑馬燈在命令列
+            // 開著的時候會直接凍結（`marquee_id` 恆為 `None`，`Tick` 那條路
+            // 永遠不會把 `marquee_frame` 往前推）。
+            View::Shell(view) => view.marquee_id(),
             _ => None,
         }
     }
@@ -81,6 +89,7 @@ impl<'a> View<'a> {
             View::List(view) => view.as_list_state().selected_row_overflows.get(),
             View::Detail(view) => view.marquee_needed(),
             View::GitHub(view) => view.marquee_needed(),
+            View::Shell(view) => view.marquee_needed(),
             _ => false,
         }
     }
@@ -89,6 +98,11 @@ impl<'a> View<'a> {
         match self {
             View::List(view) => view.take_graph_clear(),
             View::Detail(view) => view.take_graph_clear(),
+            // `open_shell()` 在包住 `before` 之前就對它呼叫過
+            // `request_graph_clear()`，旗標設在被包住的 List/Detail 身上——
+            // 不委派的話這個旗標永遠取不出來，`terminal.clear()` 也就永遠
+            // 不會執行。
+            View::Shell(view) => view.take_graph_clear(),
             _ => false,
         }
     }
@@ -97,6 +111,7 @@ impl<'a> View<'a> {
         match self {
             View::List(view) => view.request_graph_clear(),
             View::Detail(view) => view.request_graph_clear(),
+            View::Shell(view) => view.request_graph_clear(),
             _ => {}
         }
     }
@@ -111,7 +126,8 @@ impl<'a> View<'a> {
             | View::DeleteRef(_)
             | View::Help(_)
             | View::GitHub(_)
-            | View::ReleaseNotes(_) => false,
+            | View::ReleaseNotes(_)
+            | View::Shell(_) => false,
         }
     }
 
@@ -284,6 +300,28 @@ impl<'a> View<'a> {
         View::ReleaseNotes(Box::new(ReleaseNotesView::new(before, body, ctx, tx)))
     }
 
+    pub fn of_shell(
+        before: View<'a>,
+        commit: Option<Commit>,
+        refs: Vec<Ref>,
+        area_width: u16,
+        area_height: u16,
+        repo_path: PathBuf,
+        ctx: Rc<AppContext>,
+        tx: Sender,
+    ) -> Self {
+        View::Shell(Box::new(ShellView::new(
+            before,
+            commit,
+            refs,
+            area_width,
+            area_height,
+            repo_path,
+            ctx,
+            tx,
+        )))
+    }
+
     pub fn refresh(&mut self) {
         match self {
             View::Default => {}
@@ -297,6 +335,19 @@ impl<'a> View<'a> {
             View::Help(_) => {}
             View::GitHub(_) => {}
             View::ReleaseNotes(_) => {}
+            // 直接送 `AppEvent::Refresh` 會讓 `lib.rs` 整個重建 `App`，把還在
+            // 打字／看輸出的 `ShellView` 一併炸掉——Shell 的 refresh 政策是
+            // 「記個旗標，關閉時才補送」，不是「立刻做」或「什麼都不做」。
+            View::Shell(view) => view.mark_refresh_pending(),
+        }
+    }
+
+    /// `AppEvent::ShellOutputReady` 抵達時呼叫——見
+    /// `ShellView::poll_output` 的文件註解。非 Shell view 什麼都不做，
+    /// 這是正確行為（過期喚醒打到已經換掉的 view）。
+    pub fn poll_shell_output(&mut self) {
+        if let View::Shell(view) = self {
+            view.poll_output();
         }
     }
 
@@ -311,11 +362,12 @@ impl<'a> View<'a> {
                 View::DeleteTag(mut v) => return v.take_list_state().expect("missing state"),
                 View::DeleteRef(mut v) => return v.take_list_state().expect("missing state"),
                 View::UserCommand(mut v) => return v.take_list_state().expect("missing state"),
-                // Help/GitHub 是覆蓋層視圖；要展開回內部包著的 before_view。
+                // Help/GitHub/Shell 是覆蓋層視圖；要展開回內部包著的 before_view。
                 // take_before_view 會留下 View::Default，但無妨，因為 `v` 接著就會被 drop。
                 View::Help(mut v) => v.take_before_view(),
                 View::GitHub(mut v) => v.take_before_view(),
                 View::ReleaseNotes(mut v) => v.take_before_view(),
+                View::Shell(mut v) => v.take_before_view(),
                 View::Default => unreachable!("no View::Default at runtime"),
             };
         }

--- a/src/widget/commit_list/render.rs
+++ b/src/widget/commit_list/render.rs
@@ -964,6 +964,7 @@ mod tests {
                 graph_width: Some(graph_width),
                 compact: Some(CompactType::Off),
                 update: crate::update::UpdateSettings::default(),
+                shell_command: Vec::new(),
             })
         }
 
@@ -1227,6 +1228,7 @@ mod tests {
                 graph_width: Some(graph_width),
                 compact: Some(CompactType::On),
                 update: crate::update::UpdateSettings::default(),
+                shell_command: Vec::new(),
             });
             let area = Rect::new(0, 0, TERM_W, height);
             let mut buf = Buffer::empty(area);
@@ -1778,6 +1780,7 @@ mod tests {
                 graph_width: Some(GraphWidthType::Single),
                 compact: Some(CompactType::On),
                 update: crate::update::UpdateSettings::default(),
+                shell_command: Vec::new(),
             });
             let area = Rect::new(0, 0, TERM_W, 10);
             let mut buf = Buffer::empty(area);


### PR DESCRIPTION
## 變更摘要

- 在 commit list / detail view 按 `/` 開內嵌命令列：Enter 執行，輸出印在可捲動面板，指令經由 shell 執行（pipe / glob / 重導向可用），支援既有 `{{target_hash}}` 系列 marker 代入目前選取的 commit
- 支援 Working changes（virtual row）與使用者 shell alias
- code-review 修正：
  - `exec_shell_command` 在非 POSIX shell（Windows cmd、fish、nushell）下改用背景 thread 併行讀取 stderr，避免 stdout/stderr 依序讀取造成死鎖
  - `CoreShellConfig.command` 補上巢狀 `inner` 驗證，讓空字串元素能被真正擋下
  - `ShellView::run()` 在輸出面板首次出現時清除圖表殘影
  - Windows `shell_quote` 危險字元清單補上 `(` `)` `!`

Closes #79

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --verbose` 通過