### PR TITLE
fix: 背景 git 操作失敗或逾時不再讓 auto-refresh 永久卡死

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
@@ -26,6 +27,7 @@ use crate::{
     },
     graph::{Graph, GraphStyle},
     keybind::KeyBind,
+    process::run_with_timeout,
     update::UpdateSettings,
     view::{dispatch_delete_branch, RefreshViewContext, RefsOrigin, View},
     widget::{
@@ -583,7 +585,6 @@ impl App<'_> {
                     self.checkout_commit(target);
                 }
                 AppEvent::AutoRefresh => {
-                    self.ec.clear_pending_refresh();
                     self.view.refresh();
                 }
                 AppEvent::OpenRefPicker { options, kind } => {
@@ -1764,6 +1765,7 @@ impl App<'_> {
             "Fetching...".into(),
             "Fetch completed".into(),
             "Fetch failed",
+            GIT_FETCH_TIMEOUT,
         );
     }
 
@@ -1775,6 +1777,7 @@ impl App<'_> {
             format!("Checking out '{target}'..."),
             format!("Checked out '{target}'"),
             "Checkout failed",
+            GIT_CHECKOUT_TIMEOUT,
         );
     }
 }
@@ -1941,6 +1944,36 @@ fn spawn_delete_branch(
     });
 }
 
+/// `fetch --all` 的逾時預算。大 repo 的 fetch 合法超過幾十秒很常見，砍掉
+/// 一個今天會成功的操作就是 break userspace——這裡只防真的被網路黑洞吃掉
+/// 的情況。
+const GIT_FETCH_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// `checkout` 的逾時預算，刻意抓得比 fetch 大得多：中途被 kill 掉的
+/// `checkout` 會留下 `.git/index.lock`，之後這個 repo 裡每一個 git 指令都
+/// 會失敗，直到使用者手動去刪——這比洩漏一條背景 thread 嚴重得多，所以要
+/// 大到任何合法操作都碰不到，這裡只防真的卡死（例如掛掉的 smudge/clean
+/// filter）。
+const GIT_CHECKOUT_TIMEOUT: Duration = Duration::from_secs(1800);
+
+/// 背景 git 指令共用的環境設定：`raw mode + alternate screen` 的終端機上，
+/// 沒有可用 credential helper 時 git／ssh 會直接對 controlling tty 寫提示
+/// 把畫面弄爛，子行程卡到逾時才收；`fetch` 又會觸發 `gc --auto`，背景長出
+/// 一個重量級 gc 不是好事。
+///
+/// `-c gc.auto=0` 是全域選項，必須在子指令（`fetch`／`checkout`）之前，
+/// 所以這裡直接建構整個 `Command`，不是事後 `.arg()` 附加——附加在子指令
+/// 之後 git 會把它當成該子指令的位置參數解析，不是全域設定。
+fn background_git_command(repo: &Path, args: &[String]) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.args(["-c", "gc.auto=0"])
+        .args(args)
+        .current_dir(repo)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_SSH_COMMAND", "ssh -o BatchMode=yes");
+    cmd
+}
+
 fn spawn_git_task(
     repo: &Path,
     ec: &EventController,
@@ -1948,6 +1981,7 @@ fn spawn_git_task(
     pending_msg: String,
     success_msg: String,
     error_prefix: &str,
+    timeout: Duration,
 ) {
     let repo_path = repo.to_path_buf();
     let tx = ec.sender();
@@ -1962,10 +1996,8 @@ fn spawn_git_task(
     });
 
     std::thread::spawn(move || {
-        let output = std::process::Command::new("git")
-            .args(&args)
-            .current_dir(&repo_path)
-            .output();
+        let cmd = background_git_command(&repo_path, &args);
+        let output = run_with_timeout(cmd, None, timeout);
 
         tx.send(AppEvent::HidePendingOverlay);
         match output {

--- a/src/event.rs
+++ b/src/event.rs
@@ -371,7 +371,11 @@ pub struct EventController {
     rx: Receiver,
     stop: Arc<AtomicBool>,
     handle: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
-    pending_refresh: Option<Arc<AtomicBool>>,
+    /// 「已有 refresh 在路上」的一次性 token——`mark_pending_refresh` 設它、
+    /// `start_git_watcher` 的背景 thread 用 `swap(false, ...)` 消費，見該處
+    /// 註解。無條件建好（不是 `Option`）：沒有 watcher 時這個 flag 只是沒人
+    /// 讀，不是需要特判的錯誤狀態。
+    pending_refresh: Arc<AtomicBool>,
     term_signal: Arc<AtomicBool>,
     heartbeat: Arc<AtomicU64>,
 }
@@ -419,7 +423,7 @@ impl EventController {
             rx,
             stop: Arc::new(AtomicBool::new(false)),
             handle: Arc::new(Mutex::new(None)),
-            pending_refresh: None,
+            pending_refresh: Arc::new(AtomicBool::new(false)),
             term_signal,
             heartbeat: Arc::new(AtomicU64::new(0)),
         };
@@ -589,31 +593,50 @@ impl EventController {
         self.rx.recv()
     }
 
-    pub fn start_git_watcher(&mut self, repo_root: &Path) {
-        let flag = start_git_watcher(self.tx.clone(), repo_root);
-        self.pending_refresh = Some(flag);
-    }
-
-    pub fn clear_pending_refresh(&self) {
-        if let Some(ref flag) = self.pending_refresh {
-            flag.store(false, Ordering::Release);
-        }
+    pub fn start_git_watcher(&self, repo_root: &Path) {
+        start_git_watcher(self.tx.clone(), self.pending_refresh.clone(), repo_root);
     }
 
     /// 標記「已有 refresh 在路上」，讓 watcher 短期內偵測到的後續 fs 事件
     /// 被 debounce 吃掉，避免主動 refresh 後 watcher 重複觸發 slow-path。
+    ///
+    /// 一次性 token：watcher 端消費掉就清掉（見 `claim_send_slot`），不需要任何
+    /// 呼叫端負責清除。就算標記後的操作本身失敗（只送 `NotifyError`、不送
+    /// `AutoRefresh`），watcher 也不會因此永久卡住——最壞情況是多吞一次
+    /// 無關的 fs 事件。
     pub fn mark_pending_refresh(&self) {
-        if let Some(ref flag) = self.pending_refresh {
-            flag.store(true, Ordering::Release);
-        }
+        self.pending_refresh.store(true, Ordering::Release);
     }
 }
 
-pub fn start_git_watcher(tx: Sender, repo_root: &Path) -> Arc<AtomicBool> {
-    use notify_debouncer_mini::new_debouncer;
+/// 節流視窗內、或 `pending` token 被設過，都不送 `AutoRefresh`——後者是
+/// 背景 git 操作（`spawn_git_task`）主動觸發的 refresh 順便產生的 fs 事件，
+/// 不必疊加一次。抽出來獨立測：watcher thread 本身只做管線接線，這個判斷
+/// 才是真正需要單元測試覆蓋的邏輯。
+///
+/// 注意這不是 predicate——呼叫一次就會消費 `pending` token、推進
+/// `last_sent`，語意跟著改變，不能被安全地重複呼叫來「先問再做」。
+///
+/// `pending` 用 `swap(false, ...)` 消費，讀了就清掉——不像單向閂鎖那樣需要
+/// 第三方負責清除，沒有人清得掉的話，一次背景操作失敗就會把 watcher 永久
+/// 卡住。
+fn claim_send_slot(
+    pending: &AtomicBool,
+    now: Instant,
+    last_sent: &mut Instant,
+    throttle: Duration,
+) -> bool {
+    if now.duration_since(*last_sent) < throttle {
+        return false;
+    }
+    // 過了節流視窗就重設時鐘；吞掉的這批也算「已送」，讓視窗蓋住背景操作
+    // 觸發的 fs 事件尾巴，不會緊接著又被下一批事件重新判定成「該送」。
+    *last_sent = now;
+    !pending.swap(false, Ordering::AcqRel)
+}
 
-    let pending_refresh = Arc::new(AtomicBool::new(false));
-    let pending = pending_refresh.clone();
+fn start_git_watcher(tx: Sender, pending: Arc<AtomicBool>, repo_root: &Path) {
+    use notify_debouncer_mini::new_debouncer;
 
     let repo_root = repo_root.to_path_buf();
     let git_dir = repo_root
@@ -658,12 +681,8 @@ pub fn start_git_watcher(tx: Sender, repo_root: &Path) -> Arc<AtomicBool> {
                         continue;
                     }
                     let now = Instant::now();
-                    if now.duration_since(last_sent) < throttle {
-                        continue;
-                    }
-                    if !pending.swap(true, Ordering::AcqRel) {
+                    if claim_send_slot(&pending, now, &mut last_sent, throttle) {
                         tx.send(AppEvent::AutoRefresh);
-                        last_sent = now;
                     }
                 }
                 Ok(Err(_)) => {}
@@ -671,8 +690,6 @@ pub fn start_git_watcher(tx: Sender, repo_root: &Path) -> Arc<AtomicBool> {
             }
         }
     });
-
-    pending_refresh
 }
 
 /// 先走快速路徑：在任何 syscall 之前，先對原始 event path 做便宜的字串檢查。
@@ -1086,6 +1103,56 @@ mod tests {
             "心跳週期 {TICK_INTERVAL:?} 對 stall 門檻 {WATCHDOG_STALL_TIMEOUT:?} 來說太長"
         );
         assert!(WATCHDOG_INTERVAL < WATCHDOG_STALL_TIMEOUT);
+    }
+
+    // ── claim_send_slot() ──
+
+    const THROTTLE: Duration = Duration::from_secs(1);
+
+    /// 節流視窗過了、沒有 pending token：正常送出，且更新 `last_sent`。
+    #[test]
+    fn claim_send_slot_sends_when_not_throttled_and_no_pending_token() {
+        let pending = AtomicBool::new(false);
+        let mut last_sent = Instant::now() - THROTTLE * 2;
+        let now = Instant::now();
+
+        assert!(claim_send_slot(&pending, now, &mut last_sent, THROTTLE));
+        assert_eq!(last_sent, now);
+    }
+
+    /// 節流視窗內：不送，且不觸碰 `pending`（沒有消費掉任何人設的 token）。
+    #[test]
+    fn claim_send_slot_swallows_within_throttle_window_without_consuming_token() {
+        let pending = AtomicBool::new(true);
+        let mut last_sent = Instant::now();
+        let now = last_sent + THROTTLE / 2;
+
+        assert!(!claim_send_slot(&pending, now, &mut last_sent, THROTTLE));
+        assert!(
+            pending.load(Ordering::Acquire),
+            "節流視窗內不該消費 token，留給視窗外的下一次判斷"
+        );
+    }
+
+    /// `pending` 是一次性 token：第一次呼叫吞掉（不送）並清成 `false`，且更新
+    /// `last_sent`；緊接著第二次呼叫（視窗外）沒有 token 可吞，正常送出。
+    /// 這是把單向閂鎖換成消費式 token 的核心不變式：token 讀了就清，不需要
+    /// 任何第三方負責清除。
+    #[test]
+    fn claim_send_slot_consumes_pending_token_exactly_once() {
+        let pending = AtomicBool::new(true);
+        let mut last_sent = Instant::now() - THROTTLE * 2;
+        let first = Instant::now();
+
+        assert!(!claim_send_slot(&pending, first, &mut last_sent, THROTTLE));
+        assert!(!pending.load(Ordering::Acquire), "token 應該被消費掉");
+        assert_eq!(last_sent, first, "吞掉的這批也算已送，更新 last_sent");
+
+        let second = first + THROTTLE * 2;
+        assert!(
+            claim_send_slot(&pending, second, &mut last_sent, THROTTLE),
+            "token 已經被上一次呼叫消費掉，這次沒有東西可吞，該正常送出"
+        );
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,11 +1,12 @@
-use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output, Stdio};
-use std::sync::{mpsc, LazyLock, Mutex, MutexGuard};
-use std::time::{Duration, Instant};
+use std::process::Command;
+use std::sync::{LazyLock, Mutex, MutexGuard};
+use std::time::Duration;
 
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Deserializer};
+
+use crate::process::run_with_timeout;
 
 /// 反序列化時就把 emoji shortcode 展開。掛在欄位定義上而不是在 `into_gh_*` 裡逐處
 /// 賦值：`GhRelatedIssue` / `GhCommit` 是共用型別，一個宣告覆蓋所有引用點，
@@ -166,108 +167,6 @@ pub struct GitHubData {
 // ── CLI 包裝 ──
 
 const GH_TIMEOUT: Duration = Duration::from_secs(20);
-const POLL_INTERVAL: Duration = Duration::from_millis(20);
-
-/// 把 pipe 讀到底丟進 channel；呼叫端只能用 `recv_timeout` 有界地等，
-/// 不能 `join`（理由見 `run_with_timeout`）。
-fn spawn_reader<R: Read + Send + 'static>(mut pipe: R) -> mpsc::Receiver<Vec<u8>> {
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        let _ = pipe.read_to_end(&mut buf);
-        let _ = tx.send(buf);
-    });
-    rx
-}
-
-/// 逾時就砍掉的子行程執行，`run_gh`（純讀，`stdin_data = None`）跟
-/// `update_body`（要把 body 灌進 stdin，`stdin_data = Some(body)`）共用。
-///
-/// **函式內部唯一的等待機制是 `deadline`，沒有任何 `join()`**——`gh` 常會
-/// fork 出 `git` 之類的孫行程，`kill()` 只殺得掉 `gh` 自己，孫行程繼承的
-/// pipe 寫端沒關，reader thread 永遠等不到 EOF，`join()` 會卡死——這正好
-/// 是「有子行程掛在網路上」的情境，也就是這個函式最該生效的那個情境。
-/// 改用 `spawn_reader` + `recv_timeout(剩餘預算)`，不管子行程是被我們
-/// kill、還是自己結束但孫行程仍握著 pipe，都保證在 `timeout` 內返回。
-fn run_with_timeout(
-    mut cmd: Command,
-    stdin_data: Option<&[u8]>,
-    timeout: Duration,
-) -> Result<Output, String> {
-    let program = cmd.get_program().to_string_lossy().into_owned();
-    cmd.stdin(if stdin_data.is_some() {
-        Stdio::piped()
-    } else {
-        Stdio::null()
-    })
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped());
-
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("Failed to execute {program}: {e}"))?;
-
-    if let Some(data) = stdin_data {
-        // 射後不理：唯一的副作用是寫完 drop 掉 `stdin`，讓子行程收到
-        // EOF。不能等它——它可能跟 reader thread 一樣卡在孫行程手上。
-        let mut stdin = child
-            .stdin
-            .take()
-            .expect("stdin is piped when stdin_data is Some");
-        let data = data.to_vec();
-        std::thread::spawn(move || {
-            let _ = stdin.write_all(&data);
-        });
-    }
-
-    let stdout_rx = spawn_reader(child.stdout.take().expect("stdout is piped"));
-    let stderr_rx = spawn_reader(child.stderr.take().expect("stderr is piped"));
-
-    let deadline = Instant::now() + timeout;
-    let status = loop {
-        let failure = match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) if Instant::now() < deadline => {
-                std::thread::sleep(POLL_INTERVAL);
-                continue;
-            }
-            Ok(None) => format!(
-                "{program} command timed out after {}s (network issue?)",
-                timeout.as_secs()
-            ),
-            // try_wait 本身失敗（極罕見）也走同一條收尾。
-            Err(e) => format!("Failed to wait for {program}: {e}"),
-        };
-        let _ = child.kill();
-        let _ = child.wait(); // reap，不留 zombie；不等 reader thread
-        return Err(failure);
-    };
-
-    // 子行程自己結束了（不是被我們 kill），但孫行程可能仍握著 pipe 寫端
-    // 不放——用剩餘的 timeout 預算等 reader，逾時就當空輸出，不能無界等
-    // （這條路徑對應 `Command::output()`／`wait_with_output()` 今天就有
-    // 的同一個理論限制，這裡額外把它也收進同一個 deadline 預算裡）。
-    //
-    // 每次都要重算剩餘預算：算一次餵給兩個 `recv_timeout` 的話，子行程
-    // 一結束就 break（剩餘 ≈ 整個 timeout）時兩次各可耗滿，總共變成
-    // 2×timeout。（`Receiver::recv_deadline()` 能一步到位，但還是
-    // unstable，rust-lang/rust#46316，不能用。）
-    //
-    // 逾時當空輸出的後果：`run_gh` 會把空字串餵給 `parse_issues_graphql`，
-    // 使用者看到的是 JSON parse error 而不是 timed out 訊息。不改成回報
-    // 錯誤是因為 `update_body` 根本不需要 stdout，強制報錯會對「其實
-    // 成功了」的編輯回報假錯誤，而 checkbox toggle 不冪等，使用者重試
-    // 會把狀態弄反——回假成功比回假失敗安全。
-    let remaining = || deadline.saturating_duration_since(Instant::now());
-    let stdout = stdout_rx.recv_timeout(remaining()).unwrap_or_default();
-    let stderr = stderr_rx.recv_timeout(remaining()).unwrap_or_default();
-
-    Ok(Output {
-        status,
-        stdout,
-        stderr,
-    })
-}
 
 fn run_gh(path: &Path, args: &[&str]) -> Result<String, String> {
     let mut cmd = Command::new("gh");
@@ -1059,66 +958,6 @@ pub fn set_pr_draft(path: &Path, number: u64, action: PrDraftAction) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ── run_with_timeout() ──
-    //
-    // 所有逾時測試共用的預算與斷言上限。上限抓 3 倍而不是「反正很大」的
-    // 2 秒：這幾條測試唯一的價值就是證明「有界」，斷言鬆到跟預算無關就
-    // 什麼都沒證明。
-
-    const BUDGET: Duration = Duration::from_millis(150);
-    const MAX_ELAPSED: Duration = Duration::from_millis(450);
-
-    #[test]
-    fn run_with_timeout_pipes_stdin_and_captures_stdout() {
-        let output = run_with_timeout(
-            Command::new("cat"),
-            Some(b"hello\n"),
-            Duration::from_secs(5),
-        )
-        .expect("cat should succeed");
-        assert!(output.status.success());
-        assert_eq!(output.stdout, b"hello\n");
-    }
-
-    #[test]
-    fn run_with_timeout_kills_a_directly_hanging_child() {
-        let mut cmd = Command::new("sleep");
-        cmd.arg("30");
-        let start = Instant::now();
-        let err = run_with_timeout(cmd, None, BUDGET).expect_err("sleep 30 should time out");
-        assert!(err.contains("timed out"), "{err}");
-        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
-    }
-
-    #[test]
-    fn run_with_timeout_does_not_hang_when_a_killed_childs_orphan_still_holds_the_pipe() {
-        // sh 自己因為 `wait` 卡住 30 秒（觸發 kill），但它背景起的 sleep
-        // 繼承了同一組 stdout/stderr 寫端——kill 掉 sh 不會連帶殺掉 sleep，
-        // 這正是 join() 版本會卡死的情境，即使子行程本身已經被砍掉、reap 掉。
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "sleep 30 & wait"]);
-        let start = Instant::now();
-        let err = run_with_timeout(cmd, None, BUDGET)
-            .expect_err("should time out even though a grandchild still holds the pipe open");
-        assert!(err.contains("timed out"), "{err}");
-        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
-    }
-
-    #[test]
-    fn run_with_timeout_does_not_exceed_budget_when_child_exits_but_orphan_holds_the_pipe() {
-        // sh 沒有 `wait`，立刻結束（成功路徑，不會觸發 kill）；但背景的
-        // sleep 一樣繼承了 pipe 寫端還活著。這條是「remaining 算一次用
-        // 兩次」的迴歸測試：那個寫法在這裡會花掉 2×BUDGET，每次重算才會
-        // 落在 BUDGET 附近。
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "sleep 30 &"]);
-        let start = Instant::now();
-        let output = run_with_timeout(cmd, None, BUDGET)
-            .expect("sh itself exits immediately, this should not error");
-        assert!(output.status.success());
-        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
-    }
 
     /// 狀態 → 動作的映射是 hint 與實際動作的唯一來源，錯了兩邊會一起錯。
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod event;
 mod external;
 mod fuzzy;
 mod keybind;
+mod process;
 mod update;
 mod view;
 mod widget;
@@ -518,7 +519,7 @@ pub fn run() -> Result<()> {
         shell_command,
     });
 
-    let mut ec = event::EventController::init();
+    let ec = event::EventController::init();
     // 這一輪迴圈每次 `Ret::Refresh` 都會重建 `App` 並重跑到這裡——檢查要
     // spawn 在迴圈外，只在整個 process 生命週期跑一次；放進 `App::run()`
     // 開頭的話，建 tag、刪 branch、checkout 這些觸發 refresh 的操作都會

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,173 @@
+use std::io::{Read, Write};
+use std::process::{Command, Output, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// 把 pipe 讀到底丟進 channel；呼叫端只能用 `recv_timeout` 有界地等，
+/// 不能 `join`（理由見 `run_with_timeout`）。
+fn spawn_reader<R: Read + Send + 'static>(mut pipe: R) -> mpsc::Receiver<Vec<u8>> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = pipe.read_to_end(&mut buf);
+        let _ = tx.send(buf);
+    });
+    rx
+}
+
+/// 逾時就砍掉的子行程執行，`github.rs::run_gh`（純讀，`stdin_data = None`）跟
+/// `update_body`（要把 body 灌進 stdin，`stdin_data = Some(body)`）、
+/// `app.rs::spawn_git_task`（背景 `git fetch`／`checkout`）共用。
+///
+/// **函式內部唯一的等待機制是 `deadline`，沒有任何 `join()`**——子行程常會
+/// fork 出孫行程（`gh` 底下的 `git`、或使用者的 shell hook），`kill()` 只
+/// 殺得掉直接子行程，孫行程繼承的 pipe 寫端沒關，reader thread 永遠等不到
+/// EOF，`join()` 會卡死——這正好是「有子行程掛在網路上」的情境，也就是這
+/// 個函式最該生效的那個情境。改用 `spawn_reader` + `recv_timeout(剩餘預算)`，
+/// 不管子行程是被我們 kill、還是自己結束但孫行程仍握著 pipe，都保證在
+/// `timeout` 內返回。
+pub fn run_with_timeout(
+    mut cmd: Command,
+    stdin_data: Option<&[u8]>,
+    timeout: Duration,
+) -> Result<Output, String> {
+    let program = cmd.get_program().to_string_lossy().into_owned();
+    cmd.stdin(if stdin_data.is_some() {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    })
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to execute {program}: {e}"))?;
+
+    if let Some(data) = stdin_data {
+        // 射後不理：唯一的副作用是寫完 drop 掉 `stdin`，讓子行程收到
+        // EOF。不能等它——它可能跟 reader thread 一樣卡在孫行程手上。
+        let mut stdin = child
+            .stdin
+            .take()
+            .expect("stdin is piped when stdin_data is Some");
+        let data = data.to_vec();
+        std::thread::spawn(move || {
+            let _ = stdin.write_all(&data);
+        });
+    }
+
+    let stdout_rx = spawn_reader(child.stdout.take().expect("stdout is piped"));
+    let stderr_rx = spawn_reader(child.stderr.take().expect("stderr is piped"));
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        let failure = match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(POLL_INTERVAL);
+                continue;
+            }
+            Ok(None) => format!(
+                "{program} command timed out after {}s (network issue?)",
+                timeout.as_secs()
+            ),
+            // try_wait 本身失敗（極罕見）也走同一條收尾。
+            Err(e) => format!("Failed to wait for {program}: {e}"),
+        };
+        let _ = child.kill();
+        let _ = child.wait(); // reap，不留 zombie；不等 reader thread
+        return Err(failure);
+    };
+
+    // 子行程自己結束了（不是被我們 kill），但孫行程可能仍握著 pipe 寫端
+    // 不放——用剩餘的 timeout 預算等 reader，逾時就當空輸出，不能無界等
+    // （這條路徑對應 `Command::output()`／`wait_with_output()` 今天就有
+    // 的同一個理論限制，這裡額外把它也收進同一個 deadline 預算裡）。
+    //
+    // 每次都要重算剩餘預算：算一次餵給兩個 `recv_timeout` 的話，子行程
+    // 一結束就 break（剩餘 ≈ 整個 timeout）時兩次各可耗滿，總共變成
+    // 2×timeout。（`Receiver::recv_deadline()` 能一步到位，但還是
+    // unstable，rust-lang/rust#46316，不能用。）
+    //
+    // 逾時當空輸出、不是錯誤：`github.rs::run_gh` 會把空字串餵給
+    // `parse_issues_graphql`，使用者看到的是 JSON parse error 而不是
+    // timed out 訊息；但 `github.rs::update_body` 根本不讀 stdout，只看
+    // `status`，改成報錯反而會對「其實成功了」的編輯回報假錯誤——而
+    // checkbox toggle 不冪等，使用者重試會把狀態弄反。回假成功比回假
+    // 失敗安全，這個取捨對所有呼叫端一致套用，不各自決定。
+    let remaining = || deadline.saturating_duration_since(Instant::now());
+    let stdout = stdout_rx.recv_timeout(remaining()).unwrap_or_default();
+    let stderr = stderr_rx.recv_timeout(remaining()).unwrap_or_default();
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 所有逾時測試共用的預算與斷言上限。上限抓 3 倍而不是「反正很大」的
+    // 2 秒：這幾條測試唯一的價值就是證明「有界」，斷言鬆到跟預算無關就
+    // 什麼都沒證明。
+
+    const BUDGET: Duration = Duration::from_millis(150);
+    const MAX_ELAPSED: Duration = Duration::from_millis(450);
+
+    #[test]
+    fn run_with_timeout_pipes_stdin_and_captures_stdout() {
+        let output = run_with_timeout(
+            Command::new("cat"),
+            Some(b"hello\n"),
+            Duration::from_secs(5),
+        )
+        .expect("cat should succeed");
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"hello\n");
+    }
+
+    #[test]
+    fn run_with_timeout_kills_a_directly_hanging_child() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30");
+        let start = Instant::now();
+        let err = run_with_timeout(cmd, None, BUDGET).expect_err("sleep 30 should time out");
+        assert!(err.contains("timed out"), "{err}");
+        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
+    }
+
+    #[test]
+    fn run_with_timeout_does_not_hang_when_a_killed_childs_orphan_still_holds_the_pipe() {
+        // sh 自己因為 `wait` 卡住 30 秒（觸發 kill），但它背景起的 sleep
+        // 繼承了同一組 stdout/stderr 寫端——kill 掉 sh 不會連帶殺掉 sleep，
+        // 這正是 join() 版本會卡死的情境，即使子行程本身已經被砍掉、reap 掉。
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 30 & wait"]);
+        let start = Instant::now();
+        let err = run_with_timeout(cmd, None, BUDGET)
+            .expect_err("should time out even though a grandchild still holds the pipe open");
+        assert!(err.contains("timed out"), "{err}");
+        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
+    }
+
+    #[test]
+    fn run_with_timeout_does_not_exceed_budget_when_child_exits_but_orphan_holds_the_pipe() {
+        // sh 沒有 `wait`，立刻結束（成功路徑，不會觸發 kill）；但背景的
+        // sleep 一樣繼承了 pipe 寫端還活著。這條是「remaining 算一次用
+        // 兩次」的迴歸測試：那個寫法在這裡會花掉 2×BUDGET，每次重算才會
+        // 落在 BUDGET 附近。
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 30 &"]);
+        let start = Instant::now();
+        let output = run_with_timeout(cmd, None, BUDGET)
+            .expect("sh itself exits immediately, this should not error");
+        assert!(output.status.success());
+        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
+    }
+}


### PR DESCRIPTION
## 問題

`pending_refresh` 是單向閂鎖：`spawn_git_task` 送出背景 `fetch`／`checkout` 前先設 flag，只有 `AppEvent::AutoRefresh` 的 handler 會清掉它。但失敗分支只送 `NotifyError`，不送 `AutoRefresh`——沒網路時按一次 `f`，或 `checkout` 因 dirty tree 失敗，file watcher 就永久死掉，整個 session 不再自動 refresh，使用者不會知道。

另外 `spawn_git_task` 用沒有 timeout 的 `Command::output()`，網路被黑洞吃掉時 thread 永遠不返回。

## 修法

- `pending_refresh` 改成讀取者消費的一次性 token（`swap(false)` 消費），不再由第三方負責清除
- 抽出 `src/process.rs`（從 `src/github.rs` 搬 `run_with_timeout`／`spawn_reader`），`spawn_git_task` 改用它，timeout 當參數傳（fetch 60s／checkout 1800s——checkout 給得特別大是因為中途被砍會留下 `.git/index.lock`）
- 背景 git 指令加 `GIT_TERMINAL_PROMPT=0`、`GIT_SSH_COMMAND=ssh -o BatchMode=yes`、`-c gc.auto=0`，避免在 raw mode 終端機上卡住等憑證輸入

Closes #83

## 驗證

- `cargo fmt --all -- --check` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo test` 全綠（549 單元測試 + 全部整合測試）
- 手動端到端（tmux + 假 `git` 模擬卡住的 fetch）：60 秒後 timeout 自動觸發，overlay 消失、顯示錯誤訊息、鍵盤沒被卡住；之後改動檔案，file watcher 在合理時間內自癒並正常觸發 auto-refresh（舊版這裡會永久卡死）