### PR TITLE
feat: 自動偵測 GitHub remote 變化並自動 fetch

### DIFF
--- a/assets/default-config.toml
+++ b/assets/default-config.toml
@@ -22,6 +22,13 @@ interval_hours = 6      # 檢查間隔（小時），範圍 1-48；啟動查一�
 auto_restart = "off"    # off｜on——on 的話更新完不再詢問，TUI 直接重啟、CLI（-U）直接開啟
 release_notes = "on"    # off｜on——版本變了第一次啟動要不要自動跳出 release notes；--whats-new 隨時可手動查看
 
+[core.auto_fetch]
+# 背景定期偵測 git remote 是否有新內容，有就自動 fetch，對應
+# --auto-fetch/--auto-fetch-interval。只更新 remote-tracking refs，本地
+# branch 一律不動；預設關閉。
+mode = "off"          # off｜on
+interval_secs = 600   # 輪詢間隔（秒），範圍 30-3600
+
 [core.search]
 ignore_case = false  # 是否預設忽略大小寫
 fuzzy = false         # 是否預設啟用模糊比對

--- a/config.schema.json
+++ b/config.schema.json
@@ -109,6 +109,29 @@
           },
           "additionalProperties": false
         },
+        "auto_fetch": {
+          "type": "object",
+          "description": "Background auto-fetch settings. Periodically polls each git remote (via git ls-remote, not the GitHub API) and runs git fetch --all --prune when something changed. Only updates remote-tracking refs; local branches are never touched.",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "description": "Whether background auto-fetch is enabled. Disabled by default. The value specified in the command line argument takes precedence.",
+              "enum": [
+                "off",
+                "on"
+              ],
+              "default": "off"
+            },
+            "interval_secs": {
+              "type": "integer",
+              "description": "How often (in seconds) to poll remotes for changes. The value specified in the command line argument takes precedence.",
+              "minimum": 30,
+              "maximum": 3600,
+              "default": 600
+            }
+          },
+          "additionalProperties": false
+        },
         "search": {
           "type": "object",
           "description": "Default search settings",

--- a/docs/src/configurations/config-file-format.md
+++ b/docs/src/configurations/config-file-format.md
@@ -16,6 +16,10 @@ interval_hours = 6
 auto_restart = "off"
 release_notes = "on"
 
+[core.auto_fetch]
+mode = "off"
+interval_secs = 600
+
 [core.search]
 ignore_case = false
 fuzzy = false
@@ -253,6 +257,32 @@ Commit 圖形的邊線風格。
 - 可選值：
   - `off`
   - `on`
+
+命令列參數指定的值優先。
+
+### `core.auto_fetch.mode`
+
+背景定期偵測 git remote 是否有新內容，有就自動 `git fetch --all --prune`。
+只更新 remote-tracking refs（例如 `origin/main`），本地 branch 一律不動——
+不 merge、不 rebase、不 fast-forward。偵測方式是逐一比對每個 remote 的
+`git ls-remote --heads --tags` 輸出，不打 GitHub API，`upstream` 這類非
+GitHub remote 一樣顧到。
+
+- 型別：`string`（enum）
+- 預設值：`off`
+- 可選值：
+  - `off`
+  - `on`
+
+命令列參數指定的值優先。
+
+### `core.auto_fetch.interval_secs`
+
+自動 fetch 的輪詢間隔（秒）。
+
+- 型別：`integer`
+- 預設值：`600`
+- 可選範圍：`30`–`3600`
 
 命令列參數指定的值優先。
 

--- a/docs/src/getting-started/command-line-options.md
+++ b/docs/src/getting-started/command-line-options.md
@@ -197,6 +197,39 @@ _可選值：_ `off`、`on`
 
 設定檔對應鍵是 `core.update.release_notes`，命令列參數指定的值優先。
 
+## --auto-fetch \<TYPE\>
+
+背景定期偵測 git remote 是否有新內容，有就自動 `git fetch --all --prune`。
+**只更新 remote-tracking refs（例如 `origin/main`），本地 branch 一律不動**——
+不 merge、不 rebase、不 fast-forward，要不要跟上遠端由使用者自己決定。
+
+_可選值：_ `off`、`on`
+
+預設關閉：背景連網是有感知的行為，開不開由使用者明確決定。偵測方式是逐一比對
+每個 remote 的 `git ls-remote --heads --tags` 輸出，不打 GitHub API，不需要
+token、無 rate limit，`upstream` 這類非 GitHub remote 也一起顧到。
+
+開啟後啟動即檢查一次（有 remote 就會立刻同步到最新），之後依
+`--auto-fetch-interval` 設定的間隔持續輪詢。偵測到變化並成功 fetch 時，狀態列
+會跳出通知；沒有變化、或偵測／fetch 過程失敗，一律靜默，不會每個 interval 就
+彈一次錯誤。
+
+不受 `YSGIT_NO_UPDATE_CHECK` 影響——那個環境變數管的是「不要檢查更新」，跟
+auto-fetch 是不同的功能，且 auto-fetch 本來就預設關閉、需要明確開啟。
+
+背景 fetch 進行時會短暫持有 git 的鎖檔，若剛好在內嵌命令列（`/`）裡手動跑
+`git pull` 之類會碰觸相同鎖的指令，可能因此短暫失敗，重試即可。
+
+設定檔對應鍵是 `core.auto_fetch.mode`，命令列參數指定的值優先。
+
+## --auto-fetch-interval \<SECONDS\>
+
+自動 fetch 的輪詢間隔，單位秒。
+
+_可選範圍：_ `30`–`3600`，預設 `600`。
+
+設定檔對應鍵是 `core.auto_fetch.interval_secs`，命令列參數指定的值優先。
+
 ## --whats-new
 
 顯示目前這一版的 release notes 並離開，不進 TUI，不受 `--release-notes` 開關

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,4 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
@@ -13,6 +12,7 @@ use ratatui::{
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
+    auto_fetch,
     color::{ColorTheme, GraphColorSet},
     config::{CoreConfig, CoreShellConfig, UiConfig, UserCommand, UserCommandType},
     event::{AppEvent, EventController, UserEvent, UserEventWithCount},
@@ -20,7 +20,7 @@ use crate::{
         copy_to_clipboard, exec_user_command, exec_user_command_suspend, is_posix_shell,
         ExternalCommandParameters,
     },
-    git::{Commit, CommitHash, FileChange, Head, Ref, RefType, Repository},
+    git::{background_command, Commit, CommitHash, FileChange, Head, Ref, RefType, Repository},
     github::{
         is_merge_conflict_error, merge_pr, set_item_state, set_pr_draft, GhItemKind, MergeMethod,
         PrDraftAction, StateAction, StateFilter,
@@ -76,6 +76,9 @@ pub struct AppContext {
     /// 已合併 CLI／設定檔的自動更新設定，`update::spawn_check` 與
     /// `auto_restart` 的中斷判斷共用同一份，不各自再 `.or()` 一遍。
     pub update: UpdateSettings,
+    /// 已合併 CLI／設定檔的自動 fetch 設定，`AppEvent::AutoFetchPoll` 的
+    /// handler 讀 `interval` 來重新武裝下一輪。
+    pub auto_fetch: auto_fetch::AutoFetchSettings,
     /// 內嵌命令列（`/`）執行指令用的 `[程式, 旗標...]`——已解析完成的
     /// 最終值，不同於 `core_config.shell.command` 那個可能是 `None` 的
     /// 原始設定，見 `resolve_shell_command`。
@@ -585,6 +588,36 @@ impl App<'_> {
                     self.checkout_commit(target);
                 }
                 AppEvent::AutoRefresh => {
+                    self.view.refresh();
+                }
+                AppEvent::AutoFetchPoll { last_fingerprint } => {
+                    if self.pending_message.is_some() {
+                        // 有 blocking overlay：這一輪跳過網路工作，但同一顆
+                        // 指紋要原封不動送下去重新武裝——連跳過都不能連
+                        // 重新武裝一起跳過，否則這條鏈永久死掉。
+                        self.ec.sender().send_after(
+                            AppEvent::AutoFetchPoll { last_fingerprint },
+                            self.ctx.auto_fetch.interval,
+                        );
+                    } else {
+                        auto_fetch::spawn_poll(
+                            self.ec,
+                            self.repository.path(),
+                            last_fingerprint,
+                            self.ctx.auto_fetch.interval,
+                        );
+                    }
+                }
+                AppEvent::AutoFetchCompleted => {
+                    // 使用者正在 picker／輸入框裡的時候不搶 status line；
+                    // refresh 照做，只有要不要出聲用這道守衛。刻意不用
+                    // `can_interrupt()`——它連 GitHub view 都排除，而盯著
+                    // GitHub view 等 PR 被 merge 正是這個功能存在的理由。
+                    if self.status_line_state.is_idle_or_notification() {
+                        self.status_line_state.set_notification_success(
+                            status_line::AUTO_FETCH_SUCCESS_MSG.to_string(),
+                        );
+                    }
                     self.view.refresh();
                 }
                 AppEvent::OpenRefPicker { options, kind } => {
@@ -1735,16 +1768,19 @@ impl App<'_> {
     }
 
     /// 現在能不能打斷使用者：沒有 pending overlay、在三個 browsing view 之一、
-    /// 狀態列閒置或只是顯示一則通知（picker／prompt 都不算）。比
-    /// `maybe_open_update_prompt` 的守衛寬一格——理由見
-    /// `StatusLineState::is_showing_notification`。這是唯一一處判斷「可不可以
-    /// 打斷」，`auto_restart` 的無提示重啟與這裡的重啟提示共用它，兩者不准各自
-    /// 長出一份守衛。
+    /// 狀態列閒置或只是顯示一則通知（picker／prompt 都不算，理由見
+    /// `StatusLineState::is_showing_notification`）。這是唯一一處判斷「可不可以
+    /// 打斷『使用者當下正在看的 view』」，`auto_restart` 的無提示重啟與這裡的
+    /// 重啟提示共用它，兩者不准各自長出一份守衛。
+    ///
+    /// 狀態列那半（閒置或僅顯示通知）另外抽成
+    /// `StatusLineState::is_idle_or_notification`，`AppEvent::AutoFetchCompleted`
+    /// 的守衛也共用同一份——它刻意不要求 `is_browsing_view()`（見該處註解），
+    /// 所以不能直接呼叫這個函式。
     fn can_interrupt(&self) -> bool {
         self.pending_message.is_none()
             && self.view.is_browsing_view()
-            && (self.status_line_state.is_idle()
-                || self.status_line_state.is_showing_notification())
+            && self.status_line_state.is_idle_or_notification()
     }
 
     /// 下載＋替換執行檔完成，問是否要離開並以新版重啟。守衛沒過就退回通知。
@@ -1956,24 +1992,6 @@ const GIT_FETCH_TIMEOUT: Duration = Duration::from_secs(60);
 /// filter）。
 const GIT_CHECKOUT_TIMEOUT: Duration = Duration::from_secs(1800);
 
-/// 背景 git 指令共用的環境設定：`raw mode + alternate screen` 的終端機上，
-/// 沒有可用 credential helper 時 git／ssh 會直接對 controlling tty 寫提示
-/// 把畫面弄爛，子行程卡到逾時才收；`fetch` 又會觸發 `gc --auto`，背景長出
-/// 一個重量級 gc 不是好事。
-///
-/// `-c gc.auto=0` 是全域選項，必須在子指令（`fetch`／`checkout`）之前，
-/// 所以這裡直接建構整個 `Command`，不是事後 `.arg()` 附加——附加在子指令
-/// 之後 git 會把它當成該子指令的位置參數解析，不是全域設定。
-fn background_git_command(repo: &Path, args: &[String]) -> Command {
-    let mut cmd = Command::new("git");
-    cmd.args(["-c", "gc.auto=0"])
-        .args(args)
-        .current_dir(repo)
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GIT_SSH_COMMAND", "ssh -o BatchMode=yes");
-    cmd
-}
-
 fn spawn_git_task(
     repo: &Path,
     ec: &EventController,
@@ -1996,7 +2014,7 @@ fn spawn_git_task(
     });
 
     std::thread::spawn(move || {
-        let cmd = background_git_command(&repo_path, &args);
+        let cmd = background_command(&repo_path, &args);
         let output = run_with_timeout(cmd, None, timeout);
 
         tx.send(AppEvent::HidePendingOverlay);

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
@@ -26,6 +27,7 @@ use crate::{
     },
     graph::{Graph, GraphStyle},
     keybind::KeyBind,
+    process::run_with_timeout,
     update::UpdateSettings,
     view::{dispatch_delete_branch, RefreshViewContext, RefsOrigin, View},
     widget::{
@@ -583,7 +585,6 @@ impl App<'_> {
                     self.checkout_commit(target);
                 }
                 AppEvent::AutoRefresh => {
-                    self.ec.clear_pending_refresh();
                     self.view.refresh();
                 }
                 AppEvent::OpenRefPicker { options, kind } => {
@@ -1764,6 +1765,7 @@ impl App<'_> {
             "Fetching...".into(),
             "Fetch completed".into(),
             "Fetch failed",
+            GIT_FETCH_TIMEOUT,
         );
     }
 
@@ -1775,6 +1777,7 @@ impl App<'_> {
             format!("Checking out '{target}'..."),
             format!("Checked out '{target}'"),
             "Checkout failed",
+            GIT_CHECKOUT_TIMEOUT,
         );
     }
 }
@@ -1941,6 +1944,36 @@ fn spawn_delete_branch(
     });
 }
 
+/// `fetch --all` 的逾時預算。大 repo 的 fetch 合法超過幾十秒很常見，砍掉
+/// 一個今天會成功的操作就是 break userspace——這裡只防真的被網路黑洞吃掉
+/// 的情況。
+const GIT_FETCH_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// `checkout` 的逾時預算，刻意抓得比 fetch 大得多：中途被 kill 掉的
+/// `checkout` 會留下 `.git/index.lock`，之後這個 repo 裡每一個 git 指令都
+/// 會失敗，直到使用者手動去刪——這比洩漏一條背景 thread 嚴重得多，所以要
+/// 大到任何合法操作都碰不到，這裡只防真的卡死（例如掛掉的 smudge/clean
+/// filter）。
+const GIT_CHECKOUT_TIMEOUT: Duration = Duration::from_secs(1800);
+
+/// 背景 git 指令共用的環境設定：`raw mode + alternate screen` 的終端機上，
+/// 沒有可用 credential helper 時 git／ssh 會直接對 controlling tty 寫提示
+/// 把畫面弄爛，子行程卡到逾時才收；`fetch` 又會觸發 `gc --auto`，背景長出
+/// 一個重量級 gc 不是好事。
+///
+/// `-c gc.auto=0` 是全域選項，必須在子指令（`fetch`／`checkout`）之前，
+/// 所以這裡直接建構整個 `Command`，不是事後 `.arg()` 附加——附加在子指令
+/// 之後 git 會把它當成該子指令的位置參數解析，不是全域設定。
+fn background_git_command(repo: &Path, args: &[String]) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.args(["-c", "gc.auto=0"])
+        .args(args)
+        .current_dir(repo)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_SSH_COMMAND", "ssh -o BatchMode=yes");
+    cmd
+}
+
 fn spawn_git_task(
     repo: &Path,
     ec: &EventController,
@@ -1948,6 +1981,7 @@ fn spawn_git_task(
     pending_msg: String,
     success_msg: String,
     error_prefix: &str,
+    timeout: Duration,
 ) {
     let repo_path = repo.to_path_buf();
     let tx = ec.sender();
@@ -1962,10 +1996,8 @@ fn spawn_git_task(
     });
 
     std::thread::spawn(move || {
-        let output = std::process::Command::new("git")
-            .args(&args)
-            .current_dir(&repo_path)
-            .output();
+        let cmd = background_git_command(&repo_path, &args);
+        let output = run_with_timeout(cmd, None, timeout);
 
         tx.send(AppEvent::HidePendingOverlay);
         match output {

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,7 +29,7 @@ use crate::{
     keybind::KeyBind,
     process::run_with_timeout,
     update::UpdateSettings,
-    view::{dispatch_delete_branch, RefreshViewContext, RefsOrigin, View},
+    view::{dispatch_delete_branch, RefreshViewContext, RefsOrigin, View, ViewContext},
     widget::{
         commit_list::{CommitInfo, CommitListState, RawCommitIdx},
         pending_overlay::PendingOverlay,
@@ -450,6 +450,13 @@ impl App<'_> {
                 }
                 AppEvent::ShellOutputReady => {
                     self.view.poll_shell_output();
+                    // 指令跑完那一刻——watcher 在指令執行期間設過旗標的話
+                    // （`mark_refresh_pending`），現在才是安全的重建時機。
+                    if let View::Shell(ref mut view) = self.view {
+                        if let Some(context) = view.take_pending_refresh_context() {
+                            return Ok(Ret::Refresh(RefreshRequest { context }));
+                        }
+                    }
                 }
                 AppEvent::OpenReleaseNotes { body } => {
                     self.open_release_notes(body);
@@ -588,6 +595,9 @@ impl App<'_> {
                     self.checkout_commit(target);
                 }
                 AppEvent::AutoRefresh => {
+                    if let Some(request) = self.shell_refresh_request() {
+                        return Ok(Ret::Refresh(request));
+                    }
                     self.view.refresh();
                 }
                 AppEvent::AutoFetchPoll { last_fingerprint } => {
@@ -617,6 +627,9 @@ impl App<'_> {
                         self.status_line_state.set_notification_success(
                             status_line::AUTO_FETCH_SUCCESS_MSG.to_string(),
                         );
+                    }
+                    if let Some(request) = self.shell_refresh_request() {
+                        return Ok(Ret::Refresh(request));
                     }
                     self.view.refresh();
                 }
@@ -1332,9 +1345,6 @@ impl App<'_> {
             let (commit, _, refs) = selected_commit_details(self.repository, commit_list_state);
             (Some(commit), refs)
         };
-        let area_width = self.view_area.width.saturating_sub(4); // 扣掉左右 padding
-        let area_height =
-            crate::view::shell::output_pane_height(self.view_area.height).saturating_sub(1); // 扣掉上邊框，跟 render() 用同一條公式
         let repo_path = self.repository.path().to_path_buf();
         // 在 `mem::take` 之前對還沒被包住的 List/Detail 設旗標——list/detail
         // 底下多擠出一行輸入列，graph 是用終端圖形協定畫的，區域縮小不清
@@ -1347,8 +1357,6 @@ impl App<'_> {
             before_view,
             commit,
             refs,
-            area_width,
-            area_height,
             repo_path,
             self.ctx.clone(),
             self.ec.sender(),
@@ -1364,6 +1372,21 @@ impl App<'_> {
             }
             self.view.request_graph_clear();
         }
+    }
+
+    /// watcher 觸發時（`AutoRefresh` / `AutoFetchCompleted`）呼叫，讓命令列
+    /// 開著時背景 graph 也能立刻連動更新，不必等關掉命令列
+    /// （`close_shell` 的 `refresh_pending` 路徑）。只有「目前是 Shell view
+    /// 且指令沒在跑」才會回 `Some`；其他情況一律回 `None`，呼叫端照舊改呼叫
+    /// `self.view.refresh()`——非 Shell view 走原本的 `AppEvent::Refresh`
+    /// event queue，Shell 執行中則設 `refresh_pending`，等
+    /// `AppEvent::ShellOutputReady` 才補送。
+    fn shell_refresh_request(&mut self) -> Option<RefreshRequest> {
+        let View::Shell(ref mut view) = self.view else {
+            return None;
+        };
+        let context = view.take_refresh_context()?;
+        Some(RefreshRequest { context })
     }
 
     /// 這裡才是「看過」這一版 release notes 的認定時機——不是
@@ -1686,23 +1709,19 @@ impl App<'_> {
 
     fn init_with_context(&mut self, context: RefreshViewContext) {
         if let View::List(ref mut view) = self.view {
-            view.reset_commit_list_with(context.list_context());
+            view.reset_commit_list_with(&context.list);
         }
-        match context {
-            RefreshViewContext::List { .. } => {}
-            RefreshViewContext::Detail { .. } => {
+        match context.view {
+            ViewContext::List => {}
+            ViewContext::Detail => {
                 self.open_detail();
             }
-            RefreshViewContext::UserCommand {
-                user_command_context,
-                ..
-            } => {
-                self.open_user_command(user_command_context.n, None);
+            ViewContext::UserCommand { n } => {
+                self.open_user_command(n, None);
             }
-            RefreshViewContext::Refs {
+            ViewContext::Refs {
                 refs_context,
                 origin,
-                ..
             } => {
                 // origin 只是 close Refs 時「要回哪」的記號，不需要先把 view 切成 Detail
                 // 再立刻被 open_refs_with_origin take 走 list_state——那會白跑一次 git diff。
@@ -1710,6 +1729,15 @@ impl App<'_> {
                 if let View::Refs(ref mut view) = self.view {
                     view.reset_refs_with(refs_context);
                 }
+            }
+        }
+        // Shell 是疊加在 List/Detail 之上的第三個維度，等底層 view 還原完才
+        // 開——`open_shell()` 需要一個已經還原好選取狀態的 List/Detail 才能
+        // 正確取出 `{{target_hash}}` 系列 marker 用的 commit/refs。
+        if let Some(shell_context) = context.shell {
+            self.open_shell();
+            if let View::Shell(ref mut view) = self.view {
+                view.restore_state(*shell_context);
             }
         }
     }
@@ -1966,7 +1994,7 @@ fn spawn_delete_branch(
         match result {
             Ok(()) => {
                 tx.send(AppEvent::NotifySuccess(format!("Branch '{name}' deleted")));
-                tx.send(AppEvent::Refresh(RefreshViewContext::List { list_context }));
+                tx.send(AppEvent::Refresh(RefreshViewContext::list(list_context)));
             }
             Err(e) => {
                 let hint = if !force && e.contains("not fully merged") {

--- a/src/app/status_line.rs
+++ b/src/app/status_line.rs
@@ -25,6 +25,10 @@ const ESC_CANCEL: &str = "(Esc to cancel)";
 /// 守衛沒過時也是同一句，兩處共用同一份字面值不會漂移。
 pub(super) const UPDATE_INSTALLED_HINT: &str = "Updated — restart ysgit to apply";
 
+/// `AppEvent::AutoFetchCompleted` 顯示用的固定文案，唯一生產者是
+/// `app.rs` 的處理端；`auto_fetch` 模組不帶 payload，見該事件的文件。
+pub(super) const AUTO_FETCH_SUCCESS_MSG: &str = "Auto-fetched new commits";
+
 fn picker_digit_index(key: KeyEvent) -> Option<usize> {
     let KeyCode::Char(c) = key.code else {
         return None;
@@ -308,6 +312,14 @@ impl StatusLineState {
                 | StatusLine::NotificationSuccess(_)
                 | StatusLine::NotificationWarn(_)
         )
+    }
+
+    /// 狀態列現在能不能被「背景不請自來」的通知寫入：閒置，或只是壓著
+    /// 另一則通知。picker／prompt 都不算。`is_idle`／`is_showing_notification`
+    /// 各自的語意仍然分開（見上），這裡只是把兩者的 `||` 組合具名化，讓
+    /// `can_interrupt` 與背景通知的守衛共用同一份真值，不要各自手寫一次。
+    pub(super) fn is_idle_or_notification(&self) -> bool {
+        self.is_idle() || self.is_showing_notification()
     }
 
     pub(super) fn clear(&mut self) {
@@ -931,6 +943,7 @@ mod tests {
             graph_width: None,
             compact: None,
             update: crate::update::UpdateSettings::default(),
+            auto_fetch: crate::auto_fetch::AutoFetchSettings::default(),
             shell_command: Vec::new(),
         })
     }

--- a/src/auto_fetch.rs
+++ b/src/auto_fetch.rs
@@ -1,0 +1,295 @@
+//! 背景輪詢 git remote 是否有新內容，偵測到就 `git fetch`。**只更新
+//! remote-tracking refs，本地 branch 一律不動**——不 merge、不 rebase、
+//! 不 ff，使用者自己決定要不要跟上。
+//!
+//! 用 `AppEvent::AutoFetchPoll { last_fingerprint }` + `send_after` 自我
+//! 重新武裝，不是 detached thread + `loop { sleep }`——理由跟
+//! `AppEvent::PeriodicUpdateCheck` 相同，見該處註解。`last_fingerprint`
+//! 是這條鏈的累加器，不是共享狀態，靠 event payload 一路往前傳。
+//!
+//! 偵測方式是 `git ls-remote --heads --tags <remote>` 逐一比對輸出，不打
+//! GitHub API：不需要 token、無 rate limit、`upstream` 這類非 GitHub
+//! remote 也一起顧到。
+
+use std::{path::Path, process::Command, time::Duration};
+
+use clap::ValueEnum;
+use serde::Deserialize;
+
+use crate::{
+    event::{AppEvent, EventController, PendingRefreshFlag, Sender},
+    git::background_command,
+    process::run_with_timeout,
+};
+
+/// 是否開啟自動 fetch。預設關閉：背景連網是有感知的行為，開不開由使用者
+/// 明確決定，不是裝完就自動生效。
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AutoFetch {
+    #[default]
+    Off,
+    On,
+}
+
+/// 輪詢間隔的合法範圍（秒）；CLI／設定檔／精靈三處都要用同一組數字。
+/// 下限 30 秒：`LS_REMOTE_TIMEOUT` 是 10 秒，重新武裝又是等 worker 跑完
+/// 才排下一次（見模組文件），兩者天生序列化，下限不必抓得比逾時預算更
+/// 寬，只要不至於變成熱迴圈就好。
+pub const MIN_INTERVAL_SECS: u64 = 30;
+pub const MAX_INTERVAL_SECS: u64 = 3600;
+pub const DEFAULT_INTERVAL_SECS: u64 = 600;
+
+const LS_REMOTE_TIMEOUT: Duration = Duration::from_secs(10);
+/// `fetch --all --prune` 的逾時預算，跟 `app.rs::GIT_FETCH_TIMEOUT` 同一個
+/// 數字、但分開宣告——兩者觸發來源不同（使用者按 `f` vs 背景輪詢），沒有
+/// 理由綁死成同一個常數，各自表達各自呼叫端的取捨。
+const FETCH_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// CLI 與設定檔合併後的自動 fetch 設定。
+#[derive(Debug, Clone, Copy)]
+pub struct AutoFetchSettings {
+    pub mode: AutoFetch,
+    pub interval: Duration,
+}
+
+impl Default for AutoFetchSettings {
+    fn default() -> Self {
+        Self {
+            mode: AutoFetch::default(),
+            interval: Duration::from_secs(DEFAULT_INTERVAL_SECS),
+        }
+    }
+}
+
+/// `resolve()` 的一組來源（CLI 或設定檔），形狀照抄
+/// `update::UpdateOverrides`——兩個欄位型別都是 `Option`，拆開寫成位置
+/// 參數時 CLI 側跟設定檔側寫反編譯器抓不到。
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AutoFetchOverrides {
+    pub mode: Option<AutoFetch>,
+    pub interval_secs: Option<u64>,
+}
+
+/// 唯一的合併入口：CLI > 設定檔 > 內建預設。刻意不看
+/// `YSGIT_NO_UPDATE_CHECK`——那個變數的名字與語意都是「不要檢查更新」，
+/// auto-fetch 是完全不同的功能，且本來就預設關閉、需要使用者明確開啟，
+/// 讓一個叫 `NO_UPDATE_CHECK` 的變數偷偷否決使用者更晚、更明確的
+/// `auto_fetch = on` 才是 break userspace。
+pub fn resolve(cli: AutoFetchOverrides, config: AutoFetchOverrides) -> AutoFetchSettings {
+    let mode = cli.mode.or(config.mode).unwrap_or_default();
+    let interval_secs = cli
+        .interval_secs
+        .or(config.interval_secs)
+        .unwrap_or(DEFAULT_INTERVAL_SECS);
+    AutoFetchSettings {
+        mode,
+        interval: Duration::from_secs(interval_secs),
+    }
+}
+
+/// 收到 `AppEvent::AutoFetchPoll` 時呼叫。背景比對指紋、視情況 fetch，
+/// 最後才重新武裝下一輪——重新武裝必須在 worker 尾端，不能在收到事件的
+/// 當下就做：`interval` 最小值是 30 秒，`LS_REMOTE_TIMEOUT` 是 10 秒，
+/// 提早重新武裝的話，多個 remote 逾時疊加起來可能讓兩輪 poll 疊在一起、
+/// 變成兩個 `git fetch` 同時打同一個 repo。移到尾端，這條鏈天生序列化。
+///
+/// `pending_message.is_some()`（有 blocking overlay）期間要不要真的跑
+/// 這一輪，是 `App` 才看得到的狀態，由呼叫端（`app.rs`）決定要不要呼叫
+/// 這個函式；跳過的話呼叫端要自己把同一顆指紋原封不動 `send_after`
+/// 傳下去，不能連重新武裝一起跳過，否則這條鏈永久死掉。
+pub fn spawn_poll(ec: &EventController, repo: &Path, last_fingerprint: String, interval: Duration) {
+    let tx = ec.sender();
+    let pending_refresh = ec.pending_refresh_flag();
+    let repo = repo.to_path_buf();
+    std::thread::spawn(move || {
+        let next_fingerprint = poll_once(&tx, &pending_refresh, &repo, last_fingerprint);
+        tx.send_after(
+            AppEvent::AutoFetchPoll {
+                last_fingerprint: next_fingerprint,
+            },
+            interval,
+        );
+    });
+}
+
+/// 回傳值是「下一輪該拿去比對的指紋」——不是每次都等於新算出來的那個：
+/// ls-remote 失敗、或 fetch 本身失敗，都要保留舊指紋，讓下一輪重新判定
+/// 同一批差異，而不是默默放棄這次同步。
+fn poll_once(
+    tx: &Sender,
+    pending_refresh: &PendingRefreshFlag,
+    repo: &Path,
+    last_fingerprint: String,
+) -> String {
+    let Some(current) = fingerprint(repo) else {
+        // 任一 remote 的 ls-remote 失敗，整輪作廢：指紋是全有全無的東西，
+        // 拼裝的話網路抖一次會變成兩次假 fetch（先看起來變了，恢復後又
+        // 變回去，各觸發一次判定）。
+        return last_fingerprint;
+    };
+    if current == last_fingerprint {
+        return last_fingerprint;
+    }
+
+    // 有變化：跟 `spawn_git_task` 一樣先標記 token，讓 watcher 在 debounce
+    // 視窗內偵測到的 fs 事件被吞掉，不會跟這裡自己送的
+    // `AutoFetchCompleted` 疊加成兩次 refresh。bare repo 沒有 worktree、
+    // watcher 根本沒啟動，所以下面成功時必須自己觸發 refresh，不能指望
+    // watcher 順便觸發。
+    pending_refresh.mark();
+
+    let cmd = background_command(repo, ["fetch", "--all", "--prune"]);
+    let output = run_with_timeout(cmd, None, FETCH_TIMEOUT);
+    match output {
+        Ok(o) if o.status.success() => {
+            tx.send(AppEvent::AutoFetchCompleted);
+            current
+        }
+        // fetch 失敗（含逾時）：本地 remote-tracking refs 沒有真的更新，
+        // 保留舊指紋讓下一輪重試同一批差異；跟 ls-remote 失敗一樣靜默，
+        // 背景功能不該每個 interval 就彈一次錯誤。
+        _ => last_fingerprint,
+    }
+}
+
+/// 對每個 remote 跑 `git ls-remote --heads --tags`，把「remote 名字 +
+/// 輸出」逐一串成一個字串當指紋（帶名字才不會讓兩個 remote 的輸出互換
+/// 位置時看起來一樣）。任一 remote 失敗就回傳 `None`，語意見
+/// `poll_once`。
+///
+/// `--heads --tags`：GitHub 的 `refs/pull/*/merge` 是每次 base branch
+/// 前進就整批重算的——任何人 push 一次 main，所有開著的 PR 的 merge ref
+/// SHA 全變。不濾掉的話，活躍 repo 上等於「別人每 push 一次就多打一次
+/// 沒必要的 fetch，還彈一個沒東西變的通知」。
+///
+/// 這條規則只求「盡量」對齊 `git fetch` 實際更新的集合，不是「必須」：
+/// `--all` 會跳過設了 `remote.<name>.skipDefaultUpdate` 的 remote，但
+/// `git remote` 會列它；預設 `fetch` 只跟隨可從抓下來的歷史到達的 tag，
+/// 不是全部 remote tag，`--tags` 涵蓋過頭；remote 有自訂 refspec（例如
+/// 只抓 `refs/heads/main`）時 `--heads` 同樣涵蓋過頭。三者都只造成偶發
+/// 的多餘 fetch 與一個「沒東西變」的通知，修掉的成本遠高於症狀。
+///
+/// 沒有 remote（`git remote` 空輸出）時回傳空字串：跟種子指紋
+/// （`lib.rs::run()` 排的第一顆也是空字串）相等，天然是靜默 no-op，不需要
+/// 額外的「有沒有 remote」閘門，也讓使用者在 session 中途用內嵌命令列
+/// `git remote add` 之後自動開始運作。
+fn fingerprint(repo: &Path) -> Option<String> {
+    let remotes = list_remotes(repo)?;
+    let mut entries = Vec::with_capacity(remotes.len());
+    for remote in remotes {
+        let cmd = background_command(repo, ["ls-remote", "--heads", "--tags", &remote]);
+        let output = run_with_timeout(cmd, None, LS_REMOTE_TIMEOUT)
+            .ok()
+            .filter(|o| o.status.success())?;
+        entries.push((remote, String::from_utf8_lossy(&output.stdout).into_owned()));
+    }
+    Some(build_fingerprint(&entries))
+}
+
+/// 序列化格式（含「為何要帶 remote 名字」的理由）見 `fingerprint`；抽成
+/// 純函式方便獨立測試，不必真的連網路。
+fn build_fingerprint(entries: &[(String, String)]) -> String {
+    entries
+        .iter()
+        .map(|(remote, output)| format!("{remote}\n{output}\n"))
+        .collect()
+}
+
+/// `git remote` 是純本地讀取（讀 `.git/config`），不打網路，不需要
+/// `background_command` 的憑證／逾時硬化，直接跑就好。
+fn list_remotes(repo: &Path) -> Option<Vec<String>> {
+    let output = Command::new("git")
+        .arg("remote")
+        .current_dir(repo)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    Some(text.lines().map(String::from).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_prefers_cli_over_config_over_default() {
+        let settings = resolve(
+            AutoFetchOverrides {
+                mode: Some(AutoFetch::On),
+                interval_secs: Some(45),
+            },
+            AutoFetchOverrides {
+                mode: Some(AutoFetch::Off),
+                interval_secs: Some(120),
+            },
+        );
+        assert_eq!(settings.mode, AutoFetch::On);
+        assert_eq!(settings.interval, Duration::from_secs(45));
+    }
+
+    #[test]
+    fn resolve_falls_back_to_config_when_cli_is_unset() {
+        let settings = resolve(
+            AutoFetchOverrides::default(),
+            AutoFetchOverrides {
+                mode: Some(AutoFetch::On),
+                interval_secs: Some(120),
+            },
+        );
+        assert_eq!(settings.mode, AutoFetch::On);
+        assert_eq!(settings.interval, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn resolve_defaults_to_off_and_default_interval() {
+        let settings = resolve(AutoFetchOverrides::default(), AutoFetchOverrides::default());
+        assert_eq!(settings.mode, AutoFetch::Off);
+        assert_eq!(
+            settings.interval,
+            Duration::from_secs(DEFAULT_INTERVAL_SECS)
+        );
+    }
+
+    /// 沒有 remote：`git remote` 空輸出 → 指紋是空字串，跟種子指紋
+    /// （`String::new()`）相等，`poll_once` 判定成「沒有變化」而不是
+    /// 誤判成失敗或誤觸發 fetch。
+    #[test]
+    fn no_remotes_yields_empty_fingerprint_matching_the_seed() {
+        let dir = tempfile::tempdir().unwrap();
+        Command::new("git")
+            .arg("init")
+            .arg("-q")
+            .current_dir(dir.path())
+            .status()
+            .unwrap();
+
+        assert_eq!(fingerprint(dir.path()), Some(String::new()));
+    }
+
+    /// 指紋帶 remote 名字：同一份 ls-remote 輸出掛在不同 remote 名字下，
+    /// 指紋必須不同——不能只看內容，名字本身也是指紋的一部分。用純函式測，
+    /// 不必真的連網路。
+    #[test]
+    fn build_fingerprint_distinguishes_same_content_under_different_remote_names() {
+        let content = "abc123\trefs/heads/main\n".to_string();
+        let as_origin = build_fingerprint(&[("origin".to_string(), content.clone())]);
+        let as_upstream = build_fingerprint(&[("upstream".to_string(), content)]);
+        assert_ne!(as_origin, as_upstream);
+    }
+
+    /// 兩個 remote 的內容互換位置，指紋要跟著變：`("a", X), ("b", Y)` 不能
+    /// 跟 `("a", Y), ("b", X)` 算成同一個指紋。
+    #[test]
+    fn build_fingerprint_distinguishes_swapped_content_between_remotes() {
+        let x = "SHA-X\trefs/heads/main\n".to_string();
+        let y = "SHA-Y\trefs/heads/main\n".to_string();
+        let before =
+            build_fingerprint(&[("a".to_string(), x.clone()), ("b".to_string(), y.clone())]);
+        let after = build_fingerprint(&[("a".to_string(), y), ("b".to_string(), x)]);
+        assert_ne!(before, after);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ use smart_default::SmartDefault;
 use umbra::optional;
 
 use crate::{
+    auto_fetch::{AutoFetch, MAX_INTERVAL_SECS, MIN_INTERVAL_SECS},
     color::{ColorTheme, OptionalColorTheme},
     keybind::KeyBind,
     update::{AutoRestart, ReleaseNotes, UpdateMode, MAX_INTERVAL_HOURS, MIN_INTERVAL_HOURS},
@@ -168,6 +169,9 @@ pub struct CoreConfig {
     #[garde(dive)]
     #[nested]
     pub update: CoreUpdateConfig,
+    #[garde(dive)]
+    #[nested]
+    pub auto_fetch: CoreAutoFetchConfig,
 }
 
 #[optional(derives = [Deserialize])]
@@ -197,6 +201,18 @@ pub struct CoreUpdateConfig {
     pub auto_restart: Option<AutoRestart>,
     #[garde(skip)]
     pub release_notes: Option<ReleaseNotes>,
+}
+
+/// 自動偵測 git remote 是否有新內容、自動 fetch 的設定，預設關閉。
+/// `interval_secs` 要驗證範圍，理由跟 `CoreUpdateConfig.interval_hours`
+/// 一樣：設 0 會讓輪詢退化成無限打網路的熱迴圈，載入時就要擋掉。
+#[optional(derives = [Deserialize])]
+#[derive(Debug, Clone, PartialEq, Eq, SmartDefault, Validate)]
+pub struct CoreAutoFetchConfig {
+    #[garde(skip)]
+    pub mode: Option<AutoFetch>,
+    #[garde(range(min = MIN_INTERVAL_SECS, max = MAX_INTERVAL_SECS))]
+    pub interval_secs: Option<u64>,
 }
 
 #[optional(derives = [Deserialize])]
@@ -729,6 +745,10 @@ mod tests {
                     auto_restart: None,
                     release_notes: None,
                 },
+                auto_fetch: CoreAutoFetchConfig {
+                    mode: None,
+                    interval_secs: None,
+                },
                 search: CoreSearchConfig {
                     ignore_case: false,
                     fuzzy: false,
@@ -828,6 +848,10 @@ mod tests {
                     interval_hours: None,
                     auto_restart: None,
                     release_notes: None,
+                },
+                auto_fetch: CoreAutoFetchConfig {
+                    mode: None,
+                    interval_secs: None,
                 },
                 search: CoreSearchConfig {
                     ignore_case: true,
@@ -1003,12 +1027,13 @@ mod tests {
 
         let parsed: OptionalConfig = toml::from_str(example).unwrap();
         let mut actual = Config::from(parsed);
-        // `core.option`／`core.update` 的欄位與 `keybind` 是 Option，「未設定」
-        // 與「設定成預設值」在型別上不同（命令列參數要能覆蓋，所以預設留到更
-        // 後面才解析）。範例把它們明寫出來正是它的用途，比對前歸零，其餘欄位
-        // 照比。
+        // `core.option`／`core.update`／`core.auto_fetch` 的欄位與 `keybind`
+        // 是 Option，「未設定」與「設定成預設值」在型別上不同（命令列參數
+        // 要能覆蓋，所以預設留到更後面才解析）。範例把它們明寫出來正是它
+        // 的用途，比對前歸零，其餘欄位照比。
         actual.core.option = CoreOptionConfig::default();
         actual.core.update = CoreUpdateConfig::default();
+        actual.core.auto_fetch = CoreAutoFetchConfig::default();
         actual.keybind = None;
         assert_eq!(actual, Config::default());
     }
@@ -1042,9 +1067,10 @@ mod tests {
     }
 
     /// `assets/default-config.toml` 裡明寫出來的值（`core.option`／
-    /// `core.update` 除外，理由同 `documented_example_config_is_valid_...`）
-    /// 必須真的是 `Config::default()`——這是它作為「首次啟動範本」的存在
-    /// 意義：使用者看到的第一份設定檔，內容要跟沒有這份檔案時的行為一致。
+    /// `core.update`／`core.auto_fetch` 除外，理由同
+    /// `documented_example_config_is_valid_...`）必須真的是
+    /// `Config::default()`——這是它作為「首次啟動範本」的存在意義：使用者
+    /// 看到的第一份設定檔，內容要跟沒有這份檔案時的行為一致。
     #[test]
     fn default_config_asset_shows_real_defaults() {
         let asset = include_str!("../assets/default-config.toml");
@@ -1052,6 +1078,7 @@ mod tests {
         let mut actual = Config::from(parsed);
         actual.core.option = CoreOptionConfig::default();
         actual.core.update = CoreUpdateConfig::default();
+        actual.core.auto_fetch = CoreAutoFetchConfig::default();
         actual.keybind = None;
         assert_eq!(actual, Config::default());
     }
@@ -1192,6 +1219,11 @@ mod tests {
     }
 
     #[test]
+    fn auto_fetch_mode_schema_enum_matches_every_accepted_cli_value() {
+        assert_schema_enum_matches_every_accepted_cli_value::<AutoFetch>(&["auto_fetch", "mode"]);
+    }
+
+    #[test]
     fn release_notes_schema_enum_matches_every_accepted_cli_value() {
         assert_schema_enum_matches_every_accepted_cli_value::<ReleaseNotes>(&[
             "update",
@@ -1308,5 +1340,38 @@ mod tests {
         // None＝沒設定，garde 對 Option<T> 的 range 是 None 放行、Some 才驗。
         let update = CoreUpdateConfig::default();
         assert!(update.validate().is_ok());
+    }
+
+    #[test]
+    fn auto_fetch_interval_secs_zero_fails_validation() {
+        let auto_fetch = CoreAutoFetchConfig {
+            mode: None,
+            interval_secs: Some(0),
+        };
+        assert!(auto_fetch.validate().is_err());
+    }
+
+    #[test]
+    fn auto_fetch_interval_secs_above_max_fails_validation() {
+        let auto_fetch = CoreAutoFetchConfig {
+            mode: None,
+            interval_secs: Some(MAX_INTERVAL_SECS + 1),
+        };
+        assert!(auto_fetch.validate().is_err());
+    }
+
+    #[test]
+    fn auto_fetch_interval_secs_within_range_passes_validation() {
+        let auto_fetch = CoreAutoFetchConfig {
+            mode: None,
+            interval_secs: Some(MIN_INTERVAL_SECS),
+        };
+        assert!(auto_fetch.validate().is_ok());
+    }
+
+    #[test]
+    fn auto_fetch_interval_secs_unset_passes_validation() {
+        let auto_fetch = CoreAutoFetchConfig::default();
+        assert!(auto_fetch.validate().is_ok());
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -371,7 +371,11 @@ pub struct EventController {
     rx: Receiver,
     stop: Arc<AtomicBool>,
     handle: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
-    pending_refresh: Option<Arc<AtomicBool>>,
+    /// 「已有 refresh 在路上」的一次性 token——`mark_pending_refresh` 設它、
+    /// `start_git_watcher` 的背景 thread 用 `swap(false, ...)` 消費，見該處
+    /// 註解。無條件建好（不是 `Option`）：沒有 watcher 時這個 flag 只是沒人
+    /// 讀，不是需要特判的錯誤狀態。
+    pending_refresh: Arc<AtomicBool>,
     term_signal: Arc<AtomicBool>,
     heartbeat: Arc<AtomicU64>,
 }
@@ -419,7 +423,7 @@ impl EventController {
             rx,
             stop: Arc::new(AtomicBool::new(false)),
             handle: Arc::new(Mutex::new(None)),
-            pending_refresh: None,
+            pending_refresh: Arc::new(AtomicBool::new(false)),
             term_signal,
             heartbeat: Arc::new(AtomicU64::new(0)),
         };
@@ -589,31 +593,50 @@ impl EventController {
         self.rx.recv()
     }
 
-    pub fn start_git_watcher(&mut self, repo_root: &Path) {
-        let flag = start_git_watcher(self.tx.clone(), repo_root);
-        self.pending_refresh = Some(flag);
-    }
-
-    pub fn clear_pending_refresh(&self) {
-        if let Some(ref flag) = self.pending_refresh {
-            flag.store(false, Ordering::Release);
-        }
+    pub fn start_git_watcher(&self, repo_root: &Path) {
+        start_git_watcher(self.tx.clone(), self.pending_refresh.clone(), repo_root);
     }
 
     /// 標記「已有 refresh 在路上」，讓 watcher 短期內偵測到的後續 fs 事件
     /// 被 debounce 吃掉，避免主動 refresh 後 watcher 重複觸發 slow-path。
+    ///
+    /// 一次性 token：watcher 端消費掉就清掉（見 `claim_send_slot`），不需要任何
+    /// 呼叫端負責清除。就算標記後的操作本身失敗（只送 `NotifyError`、不送
+    /// `AutoRefresh`），watcher 也不會因此永久卡住——最壞情況是多吞一次
+    /// 無關的 fs 事件。
     pub fn mark_pending_refresh(&self) {
-        if let Some(ref flag) = self.pending_refresh {
-            flag.store(true, Ordering::Release);
-        }
+        self.pending_refresh.store(true, Ordering::Release);
     }
 }
 
-pub fn start_git_watcher(tx: Sender, repo_root: &Path) -> Arc<AtomicBool> {
-    use notify_debouncer_mini::new_debouncer;
+/// 節流視窗內、或 `pending` token 被設過，都不送 `AutoRefresh`——後者是
+/// 背景 git 操作（`spawn_git_task`）主動觸發的 refresh 順便產生的 fs 事件，
+/// 不必疊加一次。抽出來獨立測：watcher thread 本身只做管線接線，這個判斷
+/// 才是真正需要單元測試覆蓋的邏輯。
+///
+/// 注意這不是 predicate——呼叫一次就會消費 `pending` token、推進
+/// `last_sent`，語意跟著改變，不能被安全地重複呼叫來「先問再做」。
+///
+/// `pending` 用 `swap(false, ...)` 消費，讀了就清掉——不像單向閂鎖那樣需要
+/// 第三方負責清除，沒有人清得掉的話，一次背景操作失敗就會把 watcher 永久
+/// 卡住。
+fn claim_send_slot(
+    pending: &AtomicBool,
+    now: Instant,
+    last_sent: &mut Instant,
+    throttle: Duration,
+) -> bool {
+    if now.duration_since(*last_sent) < throttle {
+        return false;
+    }
+    // 過了節流視窗就重設時鐘；吞掉的這批也算「已送」，讓視窗蓋住背景操作
+    // 觸發的 fs 事件尾巴，不會緊接著又被下一批事件重新判定成「該送」。
+    *last_sent = now;
+    !pending.swap(false, Ordering::AcqRel)
+}
 
-    let pending_refresh = Arc::new(AtomicBool::new(false));
-    let pending = pending_refresh.clone();
+fn start_git_watcher(tx: Sender, pending: Arc<AtomicBool>, repo_root: &Path) {
+    use notify_debouncer_mini::new_debouncer;
 
     let repo_root = repo_root.to_path_buf();
     let git_dir = repo_root
@@ -658,12 +681,8 @@ pub fn start_git_watcher(tx: Sender, repo_root: &Path) -> Arc<AtomicBool> {
                         continue;
                     }
                     let now = Instant::now();
-                    if now.duration_since(last_sent) < throttle {
-                        continue;
-                    }
-                    if !pending.swap(true, Ordering::AcqRel) {
+                    if claim_send_slot(&pending, now, &mut last_sent, throttle) {
                         tx.send(AppEvent::AutoRefresh);
-                        last_sent = now;
                     }
                 }
                 Ok(Err(_)) => {}
@@ -671,8 +690,6 @@ pub fn start_git_watcher(tx: Sender, repo_root: &Path) -> Arc<AtomicBool> {
             }
         }
     });
-
-    pending_refresh
 }
 
 /// 先走快速路徑：在任何 syscall 之前，先對原始 event path 做便宜的字串檢查。
@@ -1086,6 +1103,56 @@ mod tests {
             "心跳週期 {TICK_INTERVAL:?} 對 stall 門檻 {WATCHDOG_STALL_TIMEOUT:?} 來說太長"
         );
         assert!(WATCHDOG_INTERVAL < WATCHDOG_STALL_TIMEOUT);
+    }
+
+    // ── claim_send_slot() ──
+
+    const THROTTLE: Duration = Duration::from_secs(1);
+
+    /// 節流視窗過了、沒有 pending token：正常送出，且更新 `last_sent`。
+    #[test]
+    fn claim_send_slot_sends_when_not_throttled_and_no_pending_token() {
+        let pending = AtomicBool::new(false);
+        let mut last_sent = Instant::now() - THROTTLE * 2;
+        let now = Instant::now();
+
+        assert!(claim_send_slot(&pending, now, &mut last_sent, THROTTLE));
+        assert_eq!(last_sent, now);
+    }
+
+    /// 節流視窗內：不送，且不觸碰 `pending`（沒有消費掉任何人設的 token）。
+    #[test]
+    fn claim_send_slot_swallows_within_throttle_window_without_consuming_token() {
+        let pending = AtomicBool::new(true);
+        let mut last_sent = Instant::now();
+        let now = last_sent + THROTTLE / 2;
+
+        assert!(!claim_send_slot(&pending, now, &mut last_sent, THROTTLE));
+        assert!(
+            pending.load(Ordering::Acquire),
+            "節流視窗內不該消費 token，留給視窗外的下一次判斷"
+        );
+    }
+
+    /// `pending` 是一次性 token：第一次呼叫吞掉（不送）並清成 `false`，且更新
+    /// `last_sent`；緊接著第二次呼叫（視窗外）沒有 token 可吞，正常送出。
+    /// 這是把單向閂鎖換成消費式 token 的核心不變式：token 讀了就清，不需要
+    /// 任何第三方負責清除。
+    #[test]
+    fn claim_send_slot_consumes_pending_token_exactly_once() {
+        let pending = AtomicBool::new(true);
+        let mut last_sent = Instant::now() - THROTTLE * 2;
+        let first = Instant::now();
+
+        assert!(!claim_send_slot(&pending, first, &mut last_sent, THROTTLE));
+        assert!(!pending.load(Ordering::Acquire), "token 應該被消費掉");
+        assert_eq!(last_sent, first, "吞掉的這批也算已送，更新 last_sent");
+
+        let second = first + THROTTLE * 2;
+        assert!(
+            claim_send_slot(&pending, second, &mut last_sent, THROTTLE),
+            "token 已經被上一次呼叫消費掉，這次沒有東西可吞，該正常送出"
+        );
     }
 
     #[test]

--- a/src/event.rs
+++ b/src/event.rs
@@ -249,6 +249,25 @@ pub enum AppEvent {
         action: crate::github::PrDraftAction,
         filter_state: crate::github::StateFilter,
     },
+    /// 持續運作期間每隔一個 interval 再檢查一次遠端有沒有變化——跟
+    /// `PeriodicUpdateCheck` 同一種鏈：`send_after` 自我重新武裝，不是
+    /// detached thread + `loop { sleep }`。
+    ///
+    /// `last_fingerprint` 是這條鏈的累加器，不是共享狀態：種子是空字串
+    /// （`lib.rs::run()` 只排這一次），之後每一輪都由
+    /// `auto_fetch::spawn_poll` 的背景 thread 算出下一顆、在自己收尾時
+    /// `send_after` 傳下去——重新武裝必須在 worker 尾端而不是這個事件剛
+    /// 收到時，否則 `interval` 太短、單一 remote 逾時預算又不小時，會讓
+    /// 兩輪 poll 疊在一起。
+    AutoFetchPoll {
+        last_fingerprint: String,
+    },
+    /// `auto_fetch` 背景 thread 偵測到遠端有變化、`git fetch` 成功了——
+    /// 沒有變化或任何一步失敗都不送事件（見 `auto_fetch` 模組文件），
+    /// 所以這個事件本身就代表「該讓使用者知道」，不必帶 payload：顯示的
+    /// 文案固定，見 `app.rs` 處理端。顯示與否仍要過守衛：使用者正在
+    /// picker／輸入框裡的時候不搶 status line。
+    AutoFetchCompleted,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -338,6 +357,22 @@ impl Sender {
 impl Debug for Sender {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "Sender")
+    }
+}
+
+/// `EventController::mark_pending_refresh` 的可攜版——`EventController` 不是
+/// `Clone`（`handle`／`term_signal` 這些欄位綁著整個 process 的生命週期），
+/// 塞不進 `'static` thread closure。跟 `Sender` 是同一種角色：只暴露
+/// `EventController` 內部狀態的一個輕量把手，讓背景 thread（目前只有
+/// `auto_fetch` 的 poll worker）能在真的要 fetch 之前標記 token，不需要
+/// 整個 `EventController`。
+#[derive(Clone)]
+pub struct PendingRefreshFlag(Arc<AtomicBool>);
+
+impl PendingRefreshFlag {
+    /// 語意與呼叫時機見 `EventController::mark_pending_refresh`。
+    pub fn mark(&self) {
+        self.0.store(true, Ordering::Release);
     }
 }
 
@@ -605,7 +640,13 @@ impl EventController {
     /// `AutoRefresh`），watcher 也不會因此永久卡住——最壞情況是多吞一次
     /// 無關的 fs 事件。
     pub fn mark_pending_refresh(&self) {
-        self.pending_refresh.store(true, Ordering::Release);
+        self.pending_refresh_flag().mark();
+    }
+
+    /// `mark_pending_refresh` 的可攜版，供背景 thread 使用——見
+    /// `PendingRefreshFlag` 文件。
+    pub fn pending_refresh_flag(&self) -> PendingRefreshFlag {
+        PendingRefreshFlag(self.pending_refresh.clone())
     }
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1088,6 +1088,32 @@ fn run_git_command(
     Ok(())
 }
 
+/// 會打網路（`fetch`／`ls-remote`／`checkout` 觸發的 smudge/clean filter 等）
+/// 且跑在背景 thread 的 git 指令共用的設定：`app.rs::spawn_git_task`（手動
+/// `f`／checkout）跟 `auto_fetch.rs`（背景輪詢）都需要同一套硬化。
+///
+/// `raw mode + alternate screen` 的終端機上，沒有可用 credential helper 時
+/// git／ssh 會直接對 controlling tty 寫提示把畫面弄爛，子行程卡到逾時才
+/// 收；`fetch` 又會觸發 `gc --auto`，背景長出一個重量級 gc 不是好事。
+///
+/// `-c gc.auto=0` 是全域選項，必須在子指令（`fetch`／`checkout`／
+/// `ls-remote`）之前，所以這裡直接建構整個 `Command`，不是事後 `.arg()`
+/// 附加——附加在子指令之後 git 會把它當成該子指令的位置參數解析，不是
+/// 全域設定。
+pub(crate) fn background_command<I, S>(path: &Path, args: I) -> Command
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let mut cmd = Command::new("git");
+    cmd.args(["-c", "gc.auto=0"])
+        .args(args)
+        .current_dir(path)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_SSH_COMMAND", "ssh -o BatchMode=yes");
+    cmd
+}
+
 pub fn create_tag(
     path: &Path,
     name: &str,

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,11 +1,12 @@
-use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output, Stdio};
-use std::sync::{mpsc, LazyLock, Mutex, MutexGuard};
-use std::time::{Duration, Instant};
+use std::process::Command;
+use std::sync::{LazyLock, Mutex, MutexGuard};
+use std::time::Duration;
 
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Deserializer};
+
+use crate::process::run_with_timeout;
 
 /// 反序列化時就把 emoji shortcode 展開。掛在欄位定義上而不是在 `into_gh_*` 裡逐處
 /// 賦值：`GhRelatedIssue` / `GhCommit` 是共用型別，一個宣告覆蓋所有引用點，
@@ -166,108 +167,6 @@ pub struct GitHubData {
 // ── CLI 包裝 ──
 
 const GH_TIMEOUT: Duration = Duration::from_secs(20);
-const POLL_INTERVAL: Duration = Duration::from_millis(20);
-
-/// 把 pipe 讀到底丟進 channel；呼叫端只能用 `recv_timeout` 有界地等，
-/// 不能 `join`（理由見 `run_with_timeout`）。
-fn spawn_reader<R: Read + Send + 'static>(mut pipe: R) -> mpsc::Receiver<Vec<u8>> {
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        let _ = pipe.read_to_end(&mut buf);
-        let _ = tx.send(buf);
-    });
-    rx
-}
-
-/// 逾時就砍掉的子行程執行，`run_gh`（純讀，`stdin_data = None`）跟
-/// `update_body`（要把 body 灌進 stdin，`stdin_data = Some(body)`）共用。
-///
-/// **函式內部唯一的等待機制是 `deadline`，沒有任何 `join()`**——`gh` 常會
-/// fork 出 `git` 之類的孫行程，`kill()` 只殺得掉 `gh` 自己，孫行程繼承的
-/// pipe 寫端沒關，reader thread 永遠等不到 EOF，`join()` 會卡死——這正好
-/// 是「有子行程掛在網路上」的情境，也就是這個函式最該生效的那個情境。
-/// 改用 `spawn_reader` + `recv_timeout(剩餘預算)`，不管子行程是被我們
-/// kill、還是自己結束但孫行程仍握著 pipe，都保證在 `timeout` 內返回。
-fn run_with_timeout(
-    mut cmd: Command,
-    stdin_data: Option<&[u8]>,
-    timeout: Duration,
-) -> Result<Output, String> {
-    let program = cmd.get_program().to_string_lossy().into_owned();
-    cmd.stdin(if stdin_data.is_some() {
-        Stdio::piped()
-    } else {
-        Stdio::null()
-    })
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped());
-
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("Failed to execute {program}: {e}"))?;
-
-    if let Some(data) = stdin_data {
-        // 射後不理：唯一的副作用是寫完 drop 掉 `stdin`，讓子行程收到
-        // EOF。不能等它——它可能跟 reader thread 一樣卡在孫行程手上。
-        let mut stdin = child
-            .stdin
-            .take()
-            .expect("stdin is piped when stdin_data is Some");
-        let data = data.to_vec();
-        std::thread::spawn(move || {
-            let _ = stdin.write_all(&data);
-        });
-    }
-
-    let stdout_rx = spawn_reader(child.stdout.take().expect("stdout is piped"));
-    let stderr_rx = spawn_reader(child.stderr.take().expect("stderr is piped"));
-
-    let deadline = Instant::now() + timeout;
-    let status = loop {
-        let failure = match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) if Instant::now() < deadline => {
-                std::thread::sleep(POLL_INTERVAL);
-                continue;
-            }
-            Ok(None) => format!(
-                "{program} command timed out after {}s (network issue?)",
-                timeout.as_secs()
-            ),
-            // try_wait 本身失敗（極罕見）也走同一條收尾。
-            Err(e) => format!("Failed to wait for {program}: {e}"),
-        };
-        let _ = child.kill();
-        let _ = child.wait(); // reap，不留 zombie；不等 reader thread
-        return Err(failure);
-    };
-
-    // 子行程自己結束了（不是被我們 kill），但孫行程可能仍握著 pipe 寫端
-    // 不放——用剩餘的 timeout 預算等 reader，逾時就當空輸出，不能無界等
-    // （這條路徑對應 `Command::output()`／`wait_with_output()` 今天就有
-    // 的同一個理論限制，這裡額外把它也收進同一個 deadline 預算裡）。
-    //
-    // 每次都要重算剩餘預算：算一次餵給兩個 `recv_timeout` 的話，子行程
-    // 一結束就 break（剩餘 ≈ 整個 timeout）時兩次各可耗滿，總共變成
-    // 2×timeout。（`Receiver::recv_deadline()` 能一步到位，但還是
-    // unstable，rust-lang/rust#46316，不能用。）
-    //
-    // 逾時當空輸出的後果：`run_gh` 會把空字串餵給 `parse_issues_graphql`，
-    // 使用者看到的是 JSON parse error 而不是 timed out 訊息。不改成回報
-    // 錯誤是因為 `update_body` 根本不需要 stdout，強制報錯會對「其實
-    // 成功了」的編輯回報假錯誤，而 checkbox toggle 不冪等，使用者重試
-    // 會把狀態弄反——回假成功比回假失敗安全。
-    let remaining = || deadline.saturating_duration_since(Instant::now());
-    let stdout = stdout_rx.recv_timeout(remaining()).unwrap_or_default();
-    let stderr = stderr_rx.recv_timeout(remaining()).unwrap_or_default();
-
-    Ok(Output {
-        status,
-        stdout,
-        stderr,
-    })
-}
 
 fn run_gh(path: &Path, args: &[&str]) -> Result<String, String> {
     let mut cmd = Command::new("gh");
@@ -1059,66 +958,6 @@ pub fn set_pr_draft(path: &Path, number: u64, action: PrDraftAction) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ── run_with_timeout() ──
-    //
-    // 所有逾時測試共用的預算與斷言上限。上限抓 3 倍而不是「反正很大」的
-    // 2 秒：這幾條測試唯一的價值就是證明「有界」，斷言鬆到跟預算無關就
-    // 什麼都沒證明。
-
-    const BUDGET: Duration = Duration::from_millis(150);
-    const MAX_ELAPSED: Duration = Duration::from_millis(450);
-
-    #[test]
-    fn run_with_timeout_pipes_stdin_and_captures_stdout() {
-        let output = run_with_timeout(
-            Command::new("cat"),
-            Some(b"hello\n"),
-            Duration::from_secs(5),
-        )
-        .expect("cat should succeed");
-        assert!(output.status.success());
-        assert_eq!(output.stdout, b"hello\n");
-    }
-
-    #[test]
-    fn run_with_timeout_kills_a_directly_hanging_child() {
-        let mut cmd = Command::new("sleep");
-        cmd.arg("30");
-        let start = Instant::now();
-        let err = run_with_timeout(cmd, None, BUDGET).expect_err("sleep 30 should time out");
-        assert!(err.contains("timed out"), "{err}");
-        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
-    }
-
-    #[test]
-    fn run_with_timeout_does_not_hang_when_a_killed_childs_orphan_still_holds_the_pipe() {
-        // sh 自己因為 `wait` 卡住 30 秒（觸發 kill），但它背景起的 sleep
-        // 繼承了同一組 stdout/stderr 寫端——kill 掉 sh 不會連帶殺掉 sleep，
-        // 這正是 join() 版本會卡死的情境，即使子行程本身已經被砍掉、reap 掉。
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "sleep 30 & wait"]);
-        let start = Instant::now();
-        let err = run_with_timeout(cmd, None, BUDGET)
-            .expect_err("should time out even though a grandchild still holds the pipe open");
-        assert!(err.contains("timed out"), "{err}");
-        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
-    }
-
-    #[test]
-    fn run_with_timeout_does_not_exceed_budget_when_child_exits_but_orphan_holds_the_pipe() {
-        // sh 沒有 `wait`，立刻結束（成功路徑，不會觸發 kill）；但背景的
-        // sleep 一樣繼承了 pipe 寫端還活著。這條是「remaining 算一次用
-        // 兩次」的迴歸測試：那個寫法在這裡會花掉 2×BUDGET，每次重算才會
-        // 落在 BUDGET 附近。
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "sleep 30 &"]);
-        let start = Instant::now();
-        let output = run_with_timeout(cmd, None, BUDGET)
-            .expect("sh itself exits immediately, this should not error");
-        assert!(output.status.success());
-        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
-    }
 
     /// 狀態 → 動作的映射是 hint 與實際動作的唯一來源，錯了兩邊會一起錯。
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod event;
 mod external;
 mod fuzzy;
 mod keybind;
+mod process;
 mod update;
 mod view;
 mod widget;
@@ -518,7 +519,7 @@ pub fn run() -> Result<()> {
         shell_command,
     });
 
-    let mut ec = event::EventController::init();
+    let ec = event::EventController::init();
     // 這一輪迴圈每次 `Ret::Refresh` 都會重建 `App` 並重跑到這裡——檢查要
     // spawn 在迴圈外，只在整個 process 生命週期跑一次；放進 `App::run()`
     // 開頭的話，建 tag、刪 branch、checkout 這些觸發 refresh 的操作都會

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod github;
 pub mod graph;
 
 mod app;
+mod auto_fetch;
 mod diff;
 mod emoji;
 mod event;
@@ -25,6 +26,7 @@ use std::{
 };
 
 use app::{App, Ret};
+use auto_fetch::AutoFetch;
 use clap::{CommandFactory, Parser, ValueEnum};
 use graph::Graph;
 use rustc_hash::FxHashSet;
@@ -98,6 +100,21 @@ struct Args {
     #[arg(long, value_name = "TYPE")]
     release_notes: Option<ReleaseNotes>,
 
+    /// 背景定期偵測 git remote 是否有新內容，有就自動 fetch（只更新
+    /// remote-tracking refs，本地 branch 不動）[default: off]
+    #[arg(long, value_name = "TYPE")]
+    auto_fetch: Option<AutoFetch>,
+
+    /// 自動 fetch 的輪詢間隔，單位秒 [default: 600]
+    #[arg(
+        long,
+        value_name = "SECONDS",
+        value_parser = clap::value_parser!(u64).range(
+            auto_fetch::MIN_INTERVAL_SECS..=auto_fetch::MAX_INTERVAL_SECS
+        )
+    )]
+    auto_fetch_interval: Option<u64>,
+
     /// 顯示說明
     #[arg(short = 'h', long, action = clap::ArgAction::Help)]
     help: Option<bool>,
@@ -143,6 +160,8 @@ impl Args {
             update_interval,
             auto_restart,
             release_notes,
+            auto_fetch,
+            auto_fetch_interval,
             help: _,
             version: _,
             update: _,
@@ -171,6 +190,14 @@ impl Args {
             (
                 "--release-notes",
                 release_notes.as_ref().map(wizard::variant_name),
+            ),
+            (
+                "--auto-fetch",
+                auto_fetch.as_ref().map(wizard::variant_name),
+            ),
+            (
+                "--auto-fetch-interval",
+                auto_fetch_interval.map(|s| s.to_string()),
             ),
         ] {
             if let Some(value) = value {
@@ -491,6 +518,16 @@ pub fn run() -> Result<()> {
             release_notes: core_config.update.release_notes,
         },
     );
+    let auto_fetch_settings = auto_fetch::resolve(
+        auto_fetch::AutoFetchOverrides {
+            mode: args.auto_fetch,
+            interval_secs: args.auto_fetch_interval,
+        },
+        auto_fetch::AutoFetchOverrides {
+            mode: core_config.auto_fetch.mode,
+            interval_secs: core_config.auto_fetch.interval_secs,
+        },
+    );
 
     let graph_color_set = color::GraphColorSet::new(&color_theme.graph);
 
@@ -516,6 +553,7 @@ pub fn run() -> Result<()> {
         graph_width,
         compact,
         update: update_settings,
+        auto_fetch: auto_fetch_settings,
         shell_command,
     });
 
@@ -555,6 +593,20 @@ pub fn run() -> Result<()> {
     }
 
     let mut repository = git::Repository::load(Path::new(&args.path), order, max_count)?;
+    // 排第一次 auto-fetch 輪詢，立刻送（不是 `send_after`）：種子指紋是
+    // 空字串，只要 repo 有 remote，第一輪就會判定成「有變化」而 fetch，
+    // 這是「開起來就是最新的」的來源——之後每一輪由
+    // `AppEvent::AutoFetchPoll` 的處理在 worker 尾端自我重新武裝，起點只
+    // 有這裡一個。`mode = Off` 就不排。放在 `Repository::load` 之後才排：
+    // 那一行內部已經跑過 `check_git_repository`（含 bare repo），「是不是
+    // git repo」在這裡已經被證明，不需要像 `start_git_watcher` 那樣另外用
+    // `is_inside_work_tree` 當閘門——bare repo 沒有 worktree 但照樣有
+    // remote、照樣該 auto-fetch。
+    if auto_fetch_settings.mode == AutoFetch::On {
+        ec.sender().send(event::AppEvent::AutoFetchPoll {
+            last_fingerprint: String::new(),
+        });
+    }
     let mut graph = Rc::new(graph::calc_graph(
         &repository,
         resolve_head_commit_hash(&repository).as_ref(),
@@ -810,6 +862,10 @@ mod tests {
             "on",
             "--release-notes",
             "off",
+            "--auto-fetch",
+            "on",
+            "--auto-fetch-interval",
+            "45",
             "/some/repo",
         ])
         .unwrap();
@@ -827,6 +883,8 @@ mod tests {
         assert_eq!(reparsed.update_interval, args.update_interval);
         assert_eq!(reparsed.auto_restart, args.auto_restart);
         assert_eq!(reparsed.release_notes, args.release_notes);
+        assert_eq!(reparsed.auto_fetch, args.auto_fetch);
+        assert_eq!(reparsed.auto_fetch_interval, args.auto_fetch_interval);
         assert_eq!(reparsed.path, args.path);
     }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,173 @@
+use std::io::{Read, Write};
+use std::process::{Command, Output, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// 把 pipe 讀到底丟進 channel；呼叫端只能用 `recv_timeout` 有界地等，
+/// 不能 `join`（理由見 `run_with_timeout`）。
+fn spawn_reader<R: Read + Send + 'static>(mut pipe: R) -> mpsc::Receiver<Vec<u8>> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = pipe.read_to_end(&mut buf);
+        let _ = tx.send(buf);
+    });
+    rx
+}
+
+/// 逾時就砍掉的子行程執行，`github.rs::run_gh`（純讀，`stdin_data = None`）跟
+/// `update_body`（要把 body 灌進 stdin，`stdin_data = Some(body)`）、
+/// `app.rs::spawn_git_task`（背景 `git fetch`／`checkout`）共用。
+///
+/// **函式內部唯一的等待機制是 `deadline`，沒有任何 `join()`**——子行程常會
+/// fork 出孫行程（`gh` 底下的 `git`、或使用者的 shell hook），`kill()` 只
+/// 殺得掉直接子行程，孫行程繼承的 pipe 寫端沒關，reader thread 永遠等不到
+/// EOF，`join()` 會卡死——這正好是「有子行程掛在網路上」的情境，也就是這
+/// 個函式最該生效的那個情境。改用 `spawn_reader` + `recv_timeout(剩餘預算)`，
+/// 不管子行程是被我們 kill、還是自己結束但孫行程仍握著 pipe，都保證在
+/// `timeout` 內返回。
+pub fn run_with_timeout(
+    mut cmd: Command,
+    stdin_data: Option<&[u8]>,
+    timeout: Duration,
+) -> Result<Output, String> {
+    let program = cmd.get_program().to_string_lossy().into_owned();
+    cmd.stdin(if stdin_data.is_some() {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    })
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to execute {program}: {e}"))?;
+
+    if let Some(data) = stdin_data {
+        // 射後不理：唯一的副作用是寫完 drop 掉 `stdin`，讓子行程收到
+        // EOF。不能等它——它可能跟 reader thread 一樣卡在孫行程手上。
+        let mut stdin = child
+            .stdin
+            .take()
+            .expect("stdin is piped when stdin_data is Some");
+        let data = data.to_vec();
+        std::thread::spawn(move || {
+            let _ = stdin.write_all(&data);
+        });
+    }
+
+    let stdout_rx = spawn_reader(child.stdout.take().expect("stdout is piped"));
+    let stderr_rx = spawn_reader(child.stderr.take().expect("stderr is piped"));
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        let failure = match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(POLL_INTERVAL);
+                continue;
+            }
+            Ok(None) => format!(
+                "{program} command timed out after {}s (network issue?)",
+                timeout.as_secs()
+            ),
+            // try_wait 本身失敗（極罕見）也走同一條收尾。
+            Err(e) => format!("Failed to wait for {program}: {e}"),
+        };
+        let _ = child.kill();
+        let _ = child.wait(); // reap，不留 zombie；不等 reader thread
+        return Err(failure);
+    };
+
+    // 子行程自己結束了（不是被我們 kill），但孫行程可能仍握著 pipe 寫端
+    // 不放——用剩餘的 timeout 預算等 reader，逾時就當空輸出，不能無界等
+    // （這條路徑對應 `Command::output()`／`wait_with_output()` 今天就有
+    // 的同一個理論限制，這裡額外把它也收進同一個 deadline 預算裡）。
+    //
+    // 每次都要重算剩餘預算：算一次餵給兩個 `recv_timeout` 的話，子行程
+    // 一結束就 break（剩餘 ≈ 整個 timeout）時兩次各可耗滿，總共變成
+    // 2×timeout。（`Receiver::recv_deadline()` 能一步到位，但還是
+    // unstable，rust-lang/rust#46316，不能用。）
+    //
+    // 逾時當空輸出、不是錯誤：`github.rs::run_gh` 會把空字串餵給
+    // `parse_issues_graphql`，使用者看到的是 JSON parse error 而不是
+    // timed out 訊息；但 `github.rs::update_body` 根本不讀 stdout，只看
+    // `status`，改成報錯反而會對「其實成功了」的編輯回報假錯誤——而
+    // checkbox toggle 不冪等，使用者重試會把狀態弄反。回假成功比回假
+    // 失敗安全，這個取捨對所有呼叫端一致套用，不各自決定。
+    let remaining = || deadline.saturating_duration_since(Instant::now());
+    let stdout = stdout_rx.recv_timeout(remaining()).unwrap_or_default();
+    let stderr = stderr_rx.recv_timeout(remaining()).unwrap_or_default();
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 所有逾時測試共用的預算與斷言上限。上限抓 3 倍而不是「反正很大」的
+    // 2 秒：這幾條測試唯一的價值就是證明「有界」，斷言鬆到跟預算無關就
+    // 什麼都沒證明。
+
+    const BUDGET: Duration = Duration::from_millis(150);
+    const MAX_ELAPSED: Duration = Duration::from_millis(450);
+
+    #[test]
+    fn run_with_timeout_pipes_stdin_and_captures_stdout() {
+        let output = run_with_timeout(
+            Command::new("cat"),
+            Some(b"hello\n"),
+            Duration::from_secs(5),
+        )
+        .expect("cat should succeed");
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"hello\n");
+    }
+
+    #[test]
+    fn run_with_timeout_kills_a_directly_hanging_child() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30");
+        let start = Instant::now();
+        let err = run_with_timeout(cmd, None, BUDGET).expect_err("sleep 30 should time out");
+        assert!(err.contains("timed out"), "{err}");
+        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
+    }
+
+    #[test]
+    fn run_with_timeout_does_not_hang_when_a_killed_childs_orphan_still_holds_the_pipe() {
+        // sh 自己因為 `wait` 卡住 30 秒（觸發 kill），但它背景起的 sleep
+        // 繼承了同一組 stdout/stderr 寫端——kill 掉 sh 不會連帶殺掉 sleep，
+        // 這正是 join() 版本會卡死的情境，即使子行程本身已經被砍掉、reap 掉。
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 30 & wait"]);
+        let start = Instant::now();
+        let err = run_with_timeout(cmd, None, BUDGET)
+            .expect_err("should time out even though a grandchild still holds the pipe open");
+        assert!(err.contains("timed out"), "{err}");
+        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
+    }
+
+    #[test]
+    fn run_with_timeout_does_not_exceed_budget_when_child_exits_but_orphan_holds_the_pipe() {
+        // sh 沒有 `wait`，立刻結束（成功路徑，不會觸發 kill）；但背景的
+        // sleep 一樣繼承了 pipe 寫端還活著。這條是「remaining 算一次用
+        // 兩次」的迴歸測試：那個寫法在這裡會花掉 2×BUDGET，每次重算才會
+        // 落在 BUDGET 附近。
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 30 &"]);
+        let start = Instant::now();
+        let output = run_with_timeout(cmd, None, BUDGET)
+            .expect("sh itself exits immediately, this should not error");
+        assert!(output.status.success());
+        assert!(start.elapsed() < MAX_ELAPSED, "took {:?}", start.elapsed());
+    }
+}

--- a/src/view/create_tag.rs
+++ b/src/view/create_tag.rs
@@ -213,7 +213,7 @@ impl<'a> CreateTagView<'a> {
                         "Tag created locally, but push failed: {e}"
                     )));
                     // 仍然要 refresh 以顯示本機已建立的 tag
-                    tx.send(AppEvent::Refresh(RefreshViewContext::List { list_context }));
+                    tx.send(AppEvent::Refresh(RefreshViewContext::list(list_context)));
                     return;
                 }
             }
@@ -226,7 +226,7 @@ impl<'a> CreateTagView<'a> {
             };
             tx.send(AppEvent::NotifySuccess(msg));
             tx.send(AppEvent::HidePendingOverlay);
-            tx.send(AppEvent::Refresh(RefreshViewContext::List { list_context }));
+            tx.send(AppEvent::Refresh(RefreshViewContext::list(list_context)));
         });
     }
 

--- a/src/view/delete_ref.rs
+++ b/src/view/delete_ref.rs
@@ -201,16 +201,12 @@ impl<'a> DeleteRefView<'a> {
                     };
                     tx.send(AppEvent::NotifySuccess(msg));
                     tx.send(AppEvent::HidePendingOverlay);
-                    tx.send(AppEvent::Refresh(RefreshViewContext::List {
-                        list_context: list_context.clone(),
-                    }));
+                    tx.send(AppEvent::Refresh(RefreshViewContext::list(list_context)));
                 }
                 Err(e) => {
                     // 如果本機刪除成功，仍然要 refresh UI
                     if local_deleted {
-                        tx.send(AppEvent::Refresh(RefreshViewContext::List {
-                            list_context: list_context.clone(),
-                        }));
+                        tx.send(AppEvent::Refresh(RefreshViewContext::list(list_context)));
                     }
                     tx.send(AppEvent::HidePendingOverlay);
                     tx.send(AppEvent::NotifyError(e));

--- a/src/view/delete_tag.rs
+++ b/src/view/delete_tag.rs
@@ -139,7 +139,7 @@ impl<'a> DeleteTagView<'a> {
                         "Local tag deleted, but failed to delete from remote: {e}"
                     )));
                     // 仍然要 refresh 以顯示刪除結果
-                    tx.send(AppEvent::Refresh(RefreshViewContext::List { list_context }));
+                    tx.send(AppEvent::Refresh(RefreshViewContext::list(list_context)));
                     return;
                 }
             }
@@ -152,7 +152,7 @@ impl<'a> DeleteTagView<'a> {
             };
             tx.send(AppEvent::NotifySuccess(msg));
             tx.send(AppEvent::HidePendingOverlay);
-            tx.send(AppEvent::Refresh(RefreshViewContext::List { list_context }));
+            tx.send(AppEvent::Refresh(RefreshViewContext::list(list_context)));
         });
     }
 

--- a/src/view/detail.rs
+++ b/src/view/detail.rs
@@ -9,7 +9,7 @@ use crate::{
     git::{Commit, DiffTarget, FileChange, Ref, Repository, WorkingChanges},
     view::{
         dispatch_branch_copy, dispatch_tag_copy, partition_branches, partition_tags,
-        ListRefreshViewContext, RefreshViewContext,
+        ListRefreshViewContext, RefreshViewContext, ViewContext,
     },
     widget::{
         commit_detail::{
@@ -646,9 +646,8 @@ impl<'a> DetailView<'a> {
     }
 
     pub fn refresh(&self) {
-        let list_state = self.as_list_state();
-        let list_context = ListRefreshViewContext::from(list_state);
-        let context = RefreshViewContext::Detail { list_context };
+        let list_context = ListRefreshViewContext::from(self.as_list_state());
+        let context = RefreshViewContext::new(list_context, ViewContext::Detail);
         self.tx.send(AppEvent::Refresh(context));
     }
 }

--- a/src/view/list.rs
+++ b/src/view/list.rs
@@ -359,8 +359,8 @@ impl<'a> ListView<'a> {
     pub fn refresh(&self) {
         let list_state = self.as_list_state();
         let list_context = ListRefreshViewContext::from(list_state);
-        let context = RefreshViewContext::List { list_context };
-        self.tx.send(AppEvent::Refresh(context));
+        self.tx
+            .send(AppEvent::Refresh(RefreshViewContext::list(list_context)));
     }
 
     pub fn reset_commit_list_with(&mut self, list_context: &ListRefreshViewContext) {

--- a/src/view/refs.rs
+++ b/src/view/refs.rs
@@ -10,7 +10,7 @@ use crate::{
     app::AppContext,
     event::{AppEvent, Sender, UserEvent, UserEventWithCount},
     git::{Ref, RefType},
-    view::{ListRefreshViewContext, RefreshViewContext, RefsRefreshViewContext},
+    view::{ListRefreshViewContext, RefreshViewContext, RefsRefreshViewContext, ViewContext},
     widget::{
         commit_list::{CommitList, CommitListState},
         ref_list::{RefList, RefListState},
@@ -206,18 +206,19 @@ impl<'a> RefsView<'a> {
     }
 
     pub fn refresh(&self) {
-        let list_state = self.as_list_state();
-        let list_context = ListRefreshViewContext::from(list_state);
+        let list_context = ListRefreshViewContext::from(self.as_list_state());
         let (tree_selected, tree_opened) = self.ref_list_state.current_tree_status();
         let refs_context = RefsRefreshViewContext {
             selected: tree_selected,
             opened: tree_opened,
         };
-        let context = RefreshViewContext::Refs {
+        let context = RefreshViewContext::new(
             list_context,
-            refs_context,
-            origin: self.origin,
-        };
+            ViewContext::Refs {
+                refs_context,
+                origin: self.origin,
+            },
+        );
         self.tx.send(AppEvent::Refresh(context));
     }
 

--- a/src/view/shell.rs
+++ b/src/view/shell.rs
@@ -22,7 +22,7 @@ use crate::{
     event::{AppEvent, Sender, UserEvent, UserEventWithCount},
     external::{exec_shell_command, expand_shell_command_line},
     git::{Commit, Ref},
-    view::{ansi_output_to_lines, View},
+    view::{ansi_output_to_lines, RefreshViewContext, ShellRefreshViewContext, View},
     widget::{
         output_pane::{OutputPane, OutputPaneState},
         split_at_width,
@@ -43,13 +43,6 @@ const MAX_OUTPUT_LINES: usize = 50_000;
 /// 回傳的是輸出面板的 *外框* 高度；扣掉 `OutputPane` 自己的上邊框才是內容
 /// 可用列數，呼叫端各自處理（`render()` 把它原樣交給 widget，widget 內部
 /// 自己扣；marker 算式要自己扣一次）。
-///
-/// 這兩個數字是開啟命令列當下算好、存進 `ShellView` 的快照——終端機
-/// resize 之後 `render()` 會用新的即時 `area`，但 `{{area_width}}`／
-/// `{{area_height}}` marker 展開用的還是開啟當下那份，會跟畫面顯示的
-/// 尺寸不同步。跟 user command 那條路徑一樣的取捨（`app::open_shell` /
-/// `app::build_external_command_parameters` 也是開啟當下算一次），不是
-/// 這裡才有的新問題。
 pub(crate) fn output_pane_height(area_height: u16) -> u16 {
     OUTPUT_PANE_HEIGHT.min(area_height.saturating_sub(2))
 }
@@ -93,6 +86,12 @@ pub struct ShellView<'a> {
     /// 真的含這些 marker 時才報錯，不含（`git status` 這類）照跑。
     commit: Option<Commit>,
     refs: Vec<Ref>,
+    /// `{{area_width}}`／`{{area_height}}` marker 展開用的尺寸——每次
+    /// `render()` 都會用當下的即時 `area` 覆寫，不是開啟命令列當下算好
+    /// 存住的快照。這樣終端機 resize、或這個 view 因為 repo 變動被重建
+    /// （見 `take_refresh_context`）都不會讓 marker 展開成過期的值。
+    /// 第一次 render 必定早於任何按鍵（事件迴圈是先 draw 再 recv），
+    /// `run()` 讀到的一定是對的。
     area_width: u16,
     area_height: u16,
     repo_path: PathBuf,
@@ -130,8 +129,6 @@ impl<'a> ShellView<'a> {
         before: View<'a>,
         commit: Option<Commit>,
         refs: Vec<Ref>,
-        area_width: u16,
-        area_height: u16,
         repo_path: PathBuf,
         ctx: Rc<AppContext>,
         tx: Sender,
@@ -140,8 +137,10 @@ impl<'a> ShellView<'a> {
             before,
             commit,
             refs,
-            area_width,
-            area_height,
+            // 第一次 `render()` 會在任何按鍵之前把這兩個補成真的值，見上面
+            // 欄位的文件註解。
+            area_width: 0,
+            area_height: 0,
             repo_path,
             input: Input::default(),
             history: Vec::new(),
@@ -179,17 +178,81 @@ impl<'a> ShellView<'a> {
         self.before.request_graph_clear();
     }
 
-    /// `View::refresh()` 的 Shell arm 呼叫這裡——見上面 `refresh_pending`
-    /// 的註解，這裡只記旗標，不能真的動 `before`（那會把它跟 `Refresh`
-    /// event 的 `RefreshViewContext` 綁在一起，Shell 沒有對應的 context
-    /// 變體）。故意不叫 `refresh`：其他 view 的 `refresh()` 是「立刻送出
+    /// 指令正在背景執行緒跑（`rx.is_some()`）時，watcher 說 repo 有變動，
+    /// 呼叫這裡記旗標——這時 `take_refresh_context()` 會因為 `rx` 還沒空
+    /// 而回 `None`，重建得等指令跑完、`ShellOutputReady` 抵達時才能做。
+    /// 故意不叫 `refresh`：其他 view 的 `refresh()` 是「立刻送出
     /// `AppEvent::Refresh`」，同名但語意不同容易混淆。
     pub fn mark_refresh_pending(&mut self) {
         self.refresh_pending = true;
     }
 
+    /// 使用者在指令執行中按 Esc 關閉命令列時（`app::close_shell`）呼叫，
+    /// 是這個旗標唯一還會被無條件消費（不管拿不拿得到 context）的地方——
+    /// 這種情況下命令列本身已經不在了，`before` 直接補送一般的
+    /// `AppEvent::Refresh` 即可，不需要經過 `RefreshViewContext::Shell`。
     pub fn take_refresh_pending(&mut self) -> bool {
         std::mem::take(&mut self.refresh_pending)
+    }
+
+    /// watcher 觸發、指令沒在跑時呼叫——把 `ShellView` 的狀態搬進
+    /// `RefreshViewContext::Shell`，供 `App::init_with_context` 重建後
+    /// 還原。`rx.is_some()`（指令執行中）回 `None`：那個時機不安全，狀態
+    /// 搬走的話正在跑的指令的 `Receiver` 會被連帶丟掉。
+    ///
+    /// 不搬 `rx`／`child`——呼叫這裡的前提就是它們已經是 `None`。
+    pub fn take_refresh_context(&mut self) -> Option<RefreshViewContext> {
+        if self.rx.is_some() {
+            return None;
+        }
+        let mut context = self.before.refresh_context()?;
+        context.shell = Some(Box::new(ShellRefreshViewContext {
+            input: std::mem::take(&mut self.input),
+            history: std::mem::take(&mut self.history),
+            history_index: self.history_index,
+            output_lines: std::mem::take(&mut self.output_lines),
+            output_offset: self.output_pane_state.offset(),
+        }));
+        Some(context)
+    }
+
+    /// `AppEvent::ShellOutputReady` 抵達、指令剛跑完時呼叫。
+    ///
+    /// 旗標只能在**真的拿到 context** 之後才清——`poll_output()` 的
+    /// `Empty` 分支（過期喚醒打到已經換掉的新 `ShellView`）會讓 `rx`
+    /// 維持 `Some`，`take_refresh_context()` 這時回 `None`；`?` 在那之前
+    /// 短路，`refresh_pending` 因此留著，不會被平白吃掉。反過來先清旗標
+    /// 再判斷會漏更新：跑 `sleep 10` → Esc → 重開 → 跑 `sleep 20`
+    /// （新的 `rx`）→ 舊 thread 結束送出過期的 `ShellOutputReady`，這一刻
+    /// `refresh_pending` 若恰好是真的，就會被這次無效的呼叫吃掉。
+    pub fn take_pending_refresh_context(&mut self) -> Option<RefreshViewContext> {
+        if !self.refresh_pending {
+            return None;
+        }
+        let context = self.take_refresh_context()?;
+        self.refresh_pending = false;
+        Some(context)
+    }
+
+    /// `App::init_with_context` 在 Shell 重建之後呼叫，把
+    /// `take_refresh_context()` 搬走的狀態塞回新的 `ShellView`。
+    pub fn restore_state(&mut self, shell: ShellRefreshViewContext) {
+        self.input = shell.input;
+        self.history = shell.history;
+        self.history_index = shell.history_index;
+        self.output_lines = shell.output_lines;
+        let line_count = self.output_lines.len();
+        self.output_pane_state
+            .scroll_to(shell.output_offset, line_count);
+    }
+
+    /// 換一批輸出並貼底——一般終端機的行為是新輸出進來就停在最後一行，
+    /// 不是頂端。`select_last()` 只設 `offset = usize::MAX`，實際夾值要
+    /// 等下一次 `render()`（`OutputPane::render` 先算 `height` 再
+    /// `clamp`）；這裡不需要提前知道可用行數。
+    fn set_output(&mut self, lines: Vec<Line<'static>>) {
+        self.output_lines = lines;
+        self.output_pane_state.select_last();
     }
 
     /// `AppEvent::ShellOutputReady` 抵達時呼叫。過期的喚醒（例如指令還沒
@@ -199,8 +262,7 @@ impl<'a> ShellView<'a> {
         let Some(rx) = &self.rx else { return };
         match rx.try_recv() {
             Ok(lines) => {
-                self.output_lines = lines;
-                self.output_pane_state = OutputPaneState::default();
+                self.set_output(lines);
                 self.rx = None;
             }
             Err(mpsc::TryRecvError::Empty) => {}
@@ -288,11 +350,10 @@ impl<'a> ShellView<'a> {
         ) {
             Ok(s) => s,
             Err(err) => {
-                self.output_lines = vec![Line::styled(
+                self.set_output(vec![Line::styled(
                     err,
                     Style::default().fg(self.ctx.color_theme.status_error_fg),
-                )];
-                self.output_pane_state = OutputPaneState::default();
+                )]);
                 return;
             }
         };
@@ -328,6 +389,14 @@ impl<'a> ShellView<'a> {
     }
 
     pub fn render(&mut self, f: &mut Frame, area: Rect, marquee_frame: u64) {
+        // `{{area_width}}`／`{{area_height}}` marker 用的尺寸——用當下即時
+        // `area` 更新，見欄位文件註解。算式必須跟下面的 `output_height`
+        // 各自獨立算一次：`output_height` 在 `show_output == false`
+        // 時是 0，重用同一個 local 會讓第一個指令的 `{{area_height}}`
+        // 展開成 0。
+        self.area_width = area.width.saturating_sub(4); // 扣掉左右 padding
+        self.area_height = output_pane_height(area.height).saturating_sub(1); // 扣掉上邊框
+
         let running = self.rx.is_some();
         let show_output = running || !self.output_lines.is_empty();
         let output_height = if show_output {
@@ -399,9 +468,19 @@ impl<'a> ShellView<'a> {
 
 impl Drop for ShellView<'_> {
     /// 使用者按 Esc 關閉（`before` 被 `take_before_view` 取出後，`self.view`
-    /// 被換成別的 view，這個 `Box<ShellView>` 就掉了）或整個 App 結束時都
-    /// 會經過這裡——還在跑的指令（`git push` 卡認證、寫錯的無窮迴圈）不會
-    /// 變成孤兒程序繼續握著 pipe。
+    /// 被換成別的 view，這個 `Box<ShellView>` 就掉了）、整個 App 結束、或
+    /// watcher 觸發重建（`take_refresh_context` 之後舊 `App` 被
+    /// `lib.rs` drop，見 `App::into_parts` 與慢速路徑的 `drop(app)`）時都
+    /// 會經過這裡。
+    ///
+    /// 重建這條路徑不會誤砍還在跑的指令：`take_refresh_context()` 只在
+    /// `rx.is_none()` 時才會被呼叫，而 `rx` 變成 `None` 唯一的來源是
+    /// `poll_output()`，它只在背景 thread 已經把結果送回來（或提早
+    /// disconnect）之後才設。指令仍在跑時 `rx` 是 `Some`，watcher 只會
+    /// 設 `refresh_pending`，不會觸發重建，這個 `Drop` 也就不會被呼叫到。
+    ///
+    /// 指令本身結束後才會走到這裡：還在跑的指令（`git push` 卡認證、寫錯
+    /// 的無窮迴圈）不會變成孤兒程序繼續握著 pipe。
     fn drop(&mut self) {
         if let Ok(mut guard) = self.child.lock() {
             if let Some(child) = guard.as_mut() {

--- a/src/view/user_command.rs
+++ b/src/view/user_command.rs
@@ -11,10 +11,7 @@ use crate::{
     app::AppContext,
     event::{AppEvent, Sender, UserEvent, UserEventWithCount},
     git::{Commit, Ref, Repository},
-    view::{
-        ansi_output_to_lines, ListRefreshViewContext, RefreshViewContext,
-        UserCommandRefreshViewContext,
-    },
+    view::{ansi_output_to_lines, ListRefreshViewContext, RefreshViewContext, ViewContext},
     widget::{
         commit_list::{CommitList, CommitListState},
         h,
@@ -242,15 +239,13 @@ impl<'a> UserCommandView<'a> {
     }
 
     pub fn refresh(&self) {
-        let list_state = self.as_list_state();
-        let list_context = ListRefreshViewContext::from(list_state);
-        let user_command_context = UserCommandRefreshViewContext {
-            n: self.user_command_number,
-        };
-        let context = RefreshViewContext::UserCommand {
+        let list_context = ListRefreshViewContext::from(self.as_list_state());
+        let context = RefreshViewContext::new(
             list_context,
-            user_command_context,
-        };
+            ViewContext::UserCommand {
+                n: self.user_command_number,
+            },
+        );
         self.tx.send(AppEvent::Refresh(context));
     }
 }

--- a/src/view/views.rs
+++ b/src/view/views.rs
@@ -1,6 +1,7 @@
 use std::{path::PathBuf, rc::Rc};
 
-use ratatui::{crossterm::event::KeyEvent, layout::Rect, Frame};
+use ratatui::{crossterm::event::KeyEvent, layout::Rect, text::Line, Frame};
+use tui_input::Input;
 
 use crate::{
     app::AppContext,
@@ -304,21 +305,12 @@ impl<'a> View<'a> {
         before: View<'a>,
         commit: Option<Commit>,
         refs: Vec<Ref>,
-        area_width: u16,
-        area_height: u16,
         repo_path: PathBuf,
         ctx: Rc<AppContext>,
         tx: Sender,
     ) -> Self {
         View::Shell(Box::new(ShellView::new(
-            before,
-            commit,
-            refs,
-            area_width,
-            area_height,
-            repo_path,
-            ctx,
-            tx,
+            before, commit, refs, repo_path, ctx, tx,
         )))
     }
 
@@ -351,6 +343,21 @@ impl<'a> View<'a> {
         }
     }
 
+    /// `ShellView::take_refresh_context` 用這個問「我底下包的 `before` 是
+    /// 誰、它的 list 狀態長怎樣」——`open_shell` 只接受 List/Detail
+    /// （`app::open_shell`），這裡的定義域就只需要涵蓋這兩種。
+    pub fn refresh_context(&self) -> Option<RefreshViewContext> {
+        let (list_state, view) = match self {
+            View::List(view) => (view.as_list_state(), ViewContext::List),
+            View::Detail(view) => (view.as_list_state(), ViewContext::Detail),
+            _ => return None,
+        };
+        Some(RefreshViewContext::new(
+            ListRefreshViewContext::from(list_state),
+            view,
+        ))
+    }
+
     pub fn into_commit_list_state(self) -> CommitListState<'a> {
         let mut view = self;
         loop {
@@ -374,34 +381,51 @@ impl<'a> View<'a> {
     }
 }
 
+/// 四種 browsing/dialog view 的 refresh context 曾經各是 `RefreshViewContext`
+/// 的一個 variant，但全部都帶 `list_context`——那其實是「底層 view 長怎樣」
+/// 跟「list 的捲動/選取狀態」兩個維度硬塞進同一個 enum。拆開成 `list` +
+/// `view` 兩個欄位，`shell` 是疊加在 `view` 上面的第三個、獨立的維度
+/// （只會跟 `ViewContext::List` / `ViewContext::Detail` 同時出現，因為
+/// `open_shell` 只接受這兩種 view）。
 #[derive(Debug, Clone)]
-pub enum RefreshViewContext {
-    List {
-        list_context: ListRefreshViewContext,
-    },
-    Detail {
-        list_context: ListRefreshViewContext,
-    },
-    UserCommand {
-        list_context: ListRefreshViewContext,
-        user_command_context: UserCommandRefreshViewContext,
-    },
-    Refs {
-        list_context: ListRefreshViewContext,
-        refs_context: RefsRefreshViewContext,
-        origin: RefsOrigin,
-    },
+pub struct RefreshViewContext {
+    pub list: ListRefreshViewContext,
+    pub view: ViewContext,
+    /// `Box` 是因為只有 Shell 這一條路徑會填它——不 box 的話
+    /// `AppEvent::Refresh` 這個 variant 會為了這一條路徑，讓每顆
+    /// `Tick`/`Key` 走 channel 都多搬一份沒用到的 bytes。
+    pub shell: Option<Box<ShellRefreshViewContext>>,
 }
 
 impl RefreshViewContext {
-    pub fn list_context(&self) -> &ListRefreshViewContext {
-        match self {
-            RefreshViewContext::List { list_context }
-            | RefreshViewContext::Detail { list_context }
-            | RefreshViewContext::UserCommand { list_context, .. }
-            | RefreshViewContext::Refs { list_context, .. } => list_context,
+    /// `shell` 只有 Shell 那一條路徑會填——這裡統一補 `None`，呼叫端不用
+    /// 每個都記得寫一次。
+    pub fn new(list: ListRefreshViewContext, view: ViewContext) -> Self {
+        RefreshViewContext {
+            list,
+            view,
+            shell: None,
         }
     }
+
+    /// 純粹的 List 刷新——沒有底層 view 要切換、也沒有命令列要還原。
+    /// 大多數呼叫端（建立/刪除 tag、刪除 ref 之後刷新清單）都是這個形狀。
+    pub fn list(list: ListRefreshViewContext) -> Self {
+        RefreshViewContext::new(list, ViewContext::List)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ViewContext {
+    List,
+    Detail,
+    UserCommand {
+        n: usize,
+    },
+    Refs {
+        refs_context: RefsRefreshViewContext,
+        origin: RefsOrigin,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -433,18 +457,27 @@ impl From<&CommitListState<'_>> for ListRefreshViewContext {
 pub fn send_refresh(list_state: Option<&CommitListState<'_>>, tx: &Sender) {
     if let Some(list_state) = list_state {
         let list_context = ListRefreshViewContext::from(list_state);
-        let context = RefreshViewContext::List { list_context };
-        tx.send(AppEvent::Refresh(context));
+        tx.send(AppEvent::Refresh(RefreshViewContext::list(list_context)));
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct UserCommandRefreshViewContext {
-    pub n: usize,
 }
 
 #[derive(Debug, Clone)]
 pub struct RefsRefreshViewContext {
     pub selected: Vec<String>,
     pub opened: Vec<Vec<String>>,
+}
+
+/// `ShellView` 重建時要還原的純資料——全部是 `'static`，重建當下
+/// `rx`/`child` 早就結束（見 `ShellView::take_refresh_context` 的
+/// 文件註解），不需要一起搬。
+#[derive(Debug, Clone)]
+pub struct ShellRefreshViewContext {
+    pub input: Input,
+    pub history: Vec<String>,
+    pub history_index: Option<usize>,
+    pub output_lines: Vec<Line<'static>>,
+    /// 可能是 `usize::MAX`——`OutputPaneState::select_last()` 的貼底
+    /// sentinel，還沒經過任何 render 的 clamp。還原時的 `scroll_to`
+    /// 是第一次 clamp，下一次 render 是第二次，兩次都是必要的。
+    pub output_offset: usize,
 }

--- a/src/widget/commit_list/render.rs
+++ b/src/widget/commit_list/render.rs
@@ -964,6 +964,7 @@ mod tests {
                 graph_width: Some(graph_width),
                 compact: Some(CompactType::Off),
                 update: crate::update::UpdateSettings::default(),
+                auto_fetch: crate::auto_fetch::AutoFetchSettings::default(),
                 shell_command: Vec::new(),
             })
         }
@@ -1228,6 +1229,7 @@ mod tests {
                 graph_width: Some(graph_width),
                 compact: Some(CompactType::On),
                 update: crate::update::UpdateSettings::default(),
+                auto_fetch: crate::auto_fetch::AutoFetchSettings::default(),
                 shell_command: Vec::new(),
             });
             let area = Rect::new(0, 0, TERM_W, height);
@@ -1780,6 +1782,7 @@ mod tests {
                 graph_width: Some(GraphWidthType::Single),
                 compact: Some(CompactType::On),
                 update: crate::update::UpdateSettings::default(),
+                auto_fetch: crate::auto_fetch::AutoFetchSettings::default(),
                 shell_command: Vec::new(),
             });
             let area = Rect::new(0, 0, TERM_W, 10);

--- a/src/wizard/mod.rs
+++ b/src/wizard/mod.rs
@@ -16,6 +16,7 @@ use ratatui::{
 use tui_input::backend::crossterm::EventHandler;
 
 use crate::{
+    auto_fetch::{self, AutoFetch},
     color::ColorTheme,
     config, keybind,
     update::{self, AutoRestart, ReleaseNotes, UpdateMode},
@@ -164,6 +165,13 @@ fn release_notes_desc(v: ReleaseNotes) -> &'static str {
     }
 }
 
+fn auto_fetch_desc(v: AutoFetch) -> &'static str {
+    match v {
+        AutoFetch::Off => "關閉",
+        AutoFetch::On => "開啟",
+    }
+}
+
 /// 精靈顯示「目前值」與循環切換起點用的參考點。跟 `src/lib.rs` 的 `run()`
 /// 裡 `args.field.or(core_config.option.field)` 那條合併鏈讀的是同一份
 /// 設定檔，語意也一樣（沒被使用者這次 session 動過的欄位，最終生效的值
@@ -185,6 +193,8 @@ struct ResolvedDefaults {
     update_interval: u64,
     auto_restart: AutoRestart,
     release_notes: ReleaseNotes,
+    auto_fetch: AutoFetch,
+    auto_fetch_interval: u64,
     /// 顏色編輯器的預覽基準（使用者實際設定，不是 `wizard::run()` 固定用
     /// 的畫面 chrome）。
     theme: ColorTheme,
@@ -237,6 +247,11 @@ impl ResolvedDefaults {
                 .unwrap_or(update::DEFAULT_INTERVAL_HOURS),
             auto_restart: core.update.auto_restart.unwrap_or_default(),
             release_notes: core.update.release_notes.unwrap_or_default(),
+            auto_fetch: core.auto_fetch.mode.unwrap_or_default(),
+            auto_fetch_interval: core
+                .auto_fetch
+                .interval_secs
+                .unwrap_or(auto_fetch::DEFAULT_INTERVAL_SECS),
             theme,
             keybind_patch: keybind_patch.unwrap_or_default(),
             user_commands,
@@ -317,6 +332,7 @@ struct ConfigKey {
 
 const CORE_OPTION: &[&str] = &["core", "option"];
 const CORE_UPDATE: &[&str] = &["core", "update"];
+const CORE_AUTO_FETCH: &[&str] = &["core", "auto_fetch"];
 const COLOR: &[&str] = &["color"];
 const COLOR_GRAPH: &[&str] = &["color", "graph"];
 const KEYBIND: &[&str] = &["keybind"];
@@ -332,6 +348,7 @@ enum CycleField {
     UpdateMode,
     AutoRestart,
     ReleaseNotes,
+    AutoFetch,
 }
 
 impl CycleField {
@@ -347,6 +364,7 @@ impl CycleField {
             CycleField::UpdateMode => (CORE_UPDATE, "mode"),
             CycleField::AutoRestart => (CORE_UPDATE, "auto_restart"),
             CycleField::ReleaseNotes => (CORE_UPDATE, "release_notes"),
+            CycleField::AutoFetch => (CORE_AUTO_FETCH, "mode"),
         };
         ConfigKey {
             table,
@@ -364,6 +382,7 @@ impl CycleField {
             CycleField::UpdateMode => "--update-mode",
             CycleField::AutoRestart => "--auto-restart",
             CycleField::ReleaseNotes => "--release-notes",
+            CycleField::AutoFetch => "--auto-fetch",
         }
     }
 
@@ -377,6 +396,7 @@ impl CycleField {
             CycleField::UpdateMode => "自動更新檢查模式",
             CycleField::AutoRestart => "更新後自動重啟／開啟新版",
             CycleField::ReleaseNotes => "更新後跳出 release notes",
+            CycleField::AutoFetch => "背景自動偵測 remote 並 fetch",
         }
     }
 
@@ -408,6 +428,7 @@ impl CycleField {
             CycleField::ReleaseNotes => {
                 cycle_value(&mut args.release_notes, defaults.release_notes, delta)
             }
+            CycleField::AutoFetch => cycle_value(&mut args.auto_fetch, defaults.auto_fetch, delta),
         };
         draft.edits.insert(self.config_key(), Some(name.into()));
     }
@@ -437,6 +458,9 @@ impl CycleField {
             CycleField::ReleaseNotes => {
                 release_notes_desc(args.release_notes.unwrap_or(defaults.release_notes))
             }
+            CycleField::AutoFetch => {
+                auto_fetch_desc(args.auto_fetch.unwrap_or(defaults.auto_fetch))
+            }
         }
     }
 }
@@ -453,6 +477,7 @@ struct NumberSpec {
 enum NumberField {
     MaxCount,
     UpdateInterval,
+    AutoFetchInterval,
 }
 
 impl NumberField {
@@ -466,6 +491,10 @@ impl NumberField {
                 table: CORE_UPDATE,
                 key: "interval_hours".into(),
             },
+            NumberField::AutoFetchInterval => ConfigKey {
+                table: CORE_AUTO_FETCH,
+                key: "interval_secs".into(),
+            },
         }
     }
 
@@ -473,6 +502,7 @@ impl NumberField {
         match self {
             NumberField::MaxCount => "-n, --max-count <NUMBER>",
             NumberField::UpdateInterval => "--update-interval <HOURS>",
+            NumberField::AutoFetchInterval => "--auto-fetch-interval <SECONDS>",
         }
     }
 
@@ -480,6 +510,7 @@ impl NumberField {
         match self {
             NumberField::MaxCount => "要渲染的最大 commit 數量",
             NumberField::UpdateInterval => "自動更新的檢查間隔",
+            NumberField::AutoFetchInterval => "自動 fetch 的輪詢間隔",
         }
     }
 
@@ -495,11 +526,17 @@ impl NumberField {
                 min: update::MIN_INTERVAL_HOURS as usize,
                 max: update::MAX_INTERVAL_HOURS as usize,
             },
+            NumberField::AutoFetchInterval => NumberSpec {
+                title: "自動 fetch 的輪詢間隔（秒，30–3600）",
+                min: auto_fetch::MIN_INTERVAL_SECS as usize,
+                max: auto_fetch::MAX_INTERVAL_SECS as usize,
+            },
         }
     }
 
     /// 目前有效值，也是彈窗開啟時的起始內容。`None` 只有 `max_count` 會發生
-    /// （「不限制」）——`update_interval` 一定解得出一個數字。
+    /// （「不限制」）——`update_interval`／`auto_fetch_interval` 一定解得出
+    /// 一個數字。
     fn current(self, draft: &Draft, defaults: &ResolvedDefaults) -> Option<usize> {
         match self {
             NumberField::MaxCount => draft.args.max_count.or(defaults.max_count),
@@ -509,19 +546,27 @@ impl NumberField {
                     .update_interval
                     .unwrap_or(defaults.update_interval) as usize,
             ),
+            NumberField::AutoFetchInterval => Some(
+                draft
+                    .args
+                    .auto_fetch_interval
+                    .unwrap_or(defaults.auto_fetch_interval) as usize,
+            ),
         }
     }
 
     fn current_label(self, draft: &Draft, defaults: &ResolvedDefaults) -> String {
-        // `current()` 對 UpdateInterval 一定回 `Some`（見該函式），`None` 只有
-        // MaxCount 會發生；不在這裡重算一次 `defaults.update_interval` 這個
-        // 已經在 `current()` 算過的後備值，避免同一條規則兩處真值。
+        // `current()` 對 UpdateInterval／AutoFetchInterval 一定回 `Some`
+        // （見該函式），`None` 只有 MaxCount 會發生；不在這裡重算一次
+        // `defaults.*` 這些已經在 `current()` 算過的後備值，避免同一條規則
+        // 兩處真值。
         let Some(n) = self.current(draft, defaults) else {
             return "不限制".to_string();
         };
         match self {
             NumberField::MaxCount => n.to_string(),
             NumberField::UpdateInterval => format!("{n} 小時"),
+            NumberField::AutoFetchInterval => format!("{n} 秒"),
         }
     }
 
@@ -531,6 +576,9 @@ impl NumberField {
         match self {
             NumberField::MaxCount => draft.args.max_count = value,
             NumberField::UpdateInterval => draft.args.update_interval = value.map(|n| n as u64),
+            NumberField::AutoFetchInterval => {
+                draft.args.auto_fetch_interval = value.map(|n| n as u64)
+            }
         }
         draft
             .edits
@@ -641,6 +689,10 @@ const ROWS: &[RowAction] = &[
     RowAction::Edit(Editor::Dialog(Dialog::Number(NumberField::UpdateInterval))),
     RowAction::Edit(Editor::Cycle(CycleField::AutoRestart)),
     RowAction::Edit(Editor::Cycle(CycleField::ReleaseNotes)),
+    RowAction::Edit(Editor::Cycle(CycleField::AutoFetch)),
+    RowAction::Edit(Editor::Dialog(Dialog::Number(
+        NumberField::AutoFetchInterval,
+    ))),
     RowAction::Edit(Editor::Dialog(Dialog::ColorMenu)),
     RowAction::Edit(Editor::Dialog(Dialog::KeyBindMenu)),
     RowAction::Launch,
@@ -1701,10 +1753,11 @@ mod tests {
 
     // ── 新架構釘住的不變式：ConfigKey 對應表、空 edits、PATH 的隔離 ──
 
-    /// 10 個項目全部碰過一遍，寫回、再用真正的設定檔 parser（不是自己重抄
-    /// 一份反序列化邏輯）讀回來逐欄位比對。這條測試同時證明 10 條表路徑、
-    /// 10 個鍵名（`update_mode` 寫的是 `mode`、`update_interval` 寫的是
-    /// `interval_hours`，兩個鍵名跟欄位名不同，最容易打錯）、10 個字串值
+    /// 12 個項目全部碰過一遍，寫回、再用真正的設定檔 parser（不是自己重抄
+    /// 一份反序列化邏輯）讀回來逐欄位比對。這條測試同時證明 12 條表路徑、
+    /// 12 個鍵名（`update_mode` 寫的是 `mode`、`update_interval` 寫的是
+    /// `interval_hours`、`auto_fetch` 寫的是 `mode`、`auto_fetch_interval`
+    /// 寫的是 `interval_secs`，鍵名跟欄位名不同的最容易打錯）、12 個字串值
     /// 全對——`toml_edit` 只認語法不認語意，鍵名寫錯不會有任何編譯期或
     /// 執行期警訊，只有真的讀回來比對值才抓得到。
     #[test]
@@ -1719,11 +1772,13 @@ mod tests {
             CycleField::UpdateMode,
             CycleField::AutoRestart,
             CycleField::ReleaseNotes,
+            CycleField::AutoFetch,
         ] {
             field.cycle(&mut s.draft, &s.defaults, 1);
         }
         NumberField::MaxCount.commit(&mut s.draft, Some(123));
         NumberField::UpdateInterval.commit(&mut s.draft, Some(12));
+        NumberField::AutoFetchInterval.commit(&mut s.draft, Some(45));
 
         let updated = apply_touched_settings(&s.draft, "").unwrap();
         let core = config::parse_core(&updated).unwrap();
@@ -1741,6 +1796,11 @@ mod tests {
         assert_eq!(core.update.interval_hours, s.draft.args.update_interval);
         assert_eq!(core.update.auto_restart, s.draft.args.auto_restart);
         assert_eq!(core.update.release_notes, s.draft.args.release_notes);
+        assert_eq!(core.auto_fetch.mode, s.draft.args.auto_fetch);
+        assert_eq!(
+            core.auto_fetch.interval_secs,
+            s.draft.args.auto_fetch_interval
+        );
     }
 
     /// 新架構才有的保證：`edits` 是空的，`apply_touched_settings` 一次

--- a/tests/help_flag.rs
+++ b/tests/help_flag.rs
@@ -43,6 +43,8 @@ fn help_output_lists_every_flag_including_the_new_path_browser() {
         "--update-interval",
         "--auto-restart",
         "--release-notes",
+        "--auto-fetch",
+        "--auto-fetch-interval",
         "--whats-new",
         "-h, --help",
         "-V, --version",


### PR DESCRIPTION
## 功能

背景定期偵測 git remote（不限 GitHub，`upstream` 這類非 GitHub remote 也一起顧到）是否有新內容，有就自動 `git fetch --all --prune`。**只更新 remote-tracking refs，本地 branch 一律不動**——不 merge、不 rebase、不 fast-forward，要不要跟上遠端由使用者自己決定。

## 設計

- 用 `git ls-remote --heads --tags <remote>` 輪詢每個 remote，逐一比對輸出當指紋，變了才 fetch——不打 GitHub API，不需要 token、無 rate limit
- 用 `AppEvent::AutoFetchPoll` + `send_after` 自我重新武裝，不是 detached thread；重新武裝在 worker 尾端而非收到事件當下，避免 interval 太短時兩輪 poll 疊在一起
- 種子指紋是空字串：有 remote 就第一輪必 fetch（開起來即最新）、沒 remote 就靜默 no-op；任一 remote 的 ls-remote 失敗，整輪作廢保留舊指紋，避免網路抖動造成假 fetch
- 預設關閉，`[core.auto_fetch]` 或 CLI `--auto-fetch` 開啟，`--auto-fetch-interval` 調輪詢秒數（預設 600、範圍 30–3600）；`-h` 互動式設定精靈同步支援
- `git.rs` 新增 `background_command()`：背景 git 指令共用的逾時與環境硬化，`spawn_git_task`（手動 `f`／checkout）與 auto-fetch 共用同一份

Closes #84

## 依賴 #83

本 PR 依賴 #83（先修背景 git 失敗會打死 auto-refresh 的兩個現存 bug）——auto-fetch 需要 #83 的 timeout 安全機制才能安全跑背景 git 指令。**分支是從 main 拉的獨立分支，用 cherry-pick 把 #83 的 commit 帶過來**，所以目前這份 PR diff 會包含 #83 的內容；等 #85 merge 進 main 後會 rebase 掉重複的部分。

## 內嵌命令列：輸出貼底 + 背景 graph 連動（#87）

同一分支上追加的另一項修正，與上面 auto-fetch 的內容無關：

- `OutputPaneState` 換輸出時改用 `select_last()` 貼底，不再重置回頂端——長輸出（`git log`、`cargo build`）跑完直接看到結尾
- watcher 偵測到 repo 變動時，命令列開著也會立刻重建畫面並還原輸入／歷史／輸出／捲動狀態，不必再等關閉命令列才看到 graph 更新
- 指令仍在背景執行時延後重建，等 `ShellOutputReady` 才補送，不會打斷正在跑的指令
- `RefreshViewContext` 從 enum 拆成 struct（list/view/shell 三個維度），順便修掉 `{{area_width}}`／`{{area_height}}` marker 在終端機 resize 後展開值不同步的問題

Closes #87

## 驗證

- `cargo fmt --all -- --check` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo test` 全綠（560+ 單元測試 + 全部整合測試）
- 手動端到端（本地 bare repo 模擬 remote + 兩個 clone 模擬「別人 push」）：
  - 新 commit 在 interval 內被自動抓下來，`origin/<branch>` 前進，**本地 branch 位置不變**
  - `-h` 精靈：兩個新設定項目可調、正確寫回 `.ysgit.toml`、讀回值正確
  - 預設（不帶旗標）：16 秒監控視窗內零背景 git 子行程，遠端有新 commit 也完全不受影響
- #87：tmux 實機驗證長輸出貼底、命令列開著時執行 `git commit --allow-empty` 背景 graph 即時更新（含外部 watcher 觸發與指令執行中延後補送兩條路徑）、捲動位置與輸入歷史皆保留
