### PR TITLE
feat: auto-fetch 開啟時狀態列顯示下一輪的倒數計時 (#88)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -193,6 +193,10 @@ pub struct App<'a> {
     marquee_frame: u64,
     marquee_needed: bool,
     last_marquee_id: Option<std::sync::Arc<str>>,
+    /// 上一幀畫出來的 auto-fetch 倒數秒數，`Tick` 用它判斷這一幀要不要重畫
+    /// （見 `run()` 的 `Tick` arm）。跟上面兩個欄位同一類「上一幀畫了什麼」的
+    /// 狀態；`App` 重建時歸 `None`，最多多畫一幀，無妨。
+    last_countdown_secs: Option<u64>,
 }
 
 /// GitHub 資料的排程狀態機。`(loading=false, pending=Some(_))`
@@ -319,7 +323,8 @@ impl<'a> App<'a> {
             }
         }
         let view = View::of_list(commit_list_state, ctx.clone(), ec.sender());
-        let status_line_state = StatusLineState::new(ctx.clone(), ec.sender());
+        let status_line_state =
+            StatusLineState::new(ctx.clone(), ec.sender(), ec.auto_fetch_clock());
 
         let mut app = Self {
             repository,
@@ -335,6 +340,7 @@ impl<'a> App<'a> {
             marquee_frame: 0,
             marquee_needed: false,
             last_marquee_id: None,
+            last_countdown_secs: None,
         };
 
         if let Some(context) = refresh_view_context {
@@ -375,9 +381,21 @@ impl App<'_> {
 
             match self.ec.recv() {
                 AppEvent::Tick => {
+                    // Tick 是 100ms 一次，但倒數每秒才需要動一次——以「該顯示
+                    // 的秒數變了」當重畫條件，沒開 auto-fetch 時
+                    // `countdown_secs()` 恆為 `None`，`changed` 恆為 false，
+                    // `skip_draw` 的行為跟這個功能出現之前完全一樣。
+                    //
+                    // 這三行放在 `if` 外面、無條件執行，不要搬進 `else`
+                    // 分支：那樣跑馬燈期間根本不會算，欄位會一路發霉，跑馬燈
+                    // 停下來的那一刻就用一個過期值去比對。
+                    let countdown = self.status_line_state.countdown_secs();
+                    let changed = countdown != self.last_countdown_secs;
+                    self.last_countdown_secs = countdown;
+
                     if self.marquee_needed {
                         self.marquee_frame = self.marquee_frame.wrapping_add(1);
-                    } else {
+                    } else if !changed {
                         skip_draw = true;
                     }
                     continue;
@@ -608,8 +626,15 @@ impl App<'_> {
                         // 有 blocking overlay：這一輪跳過網路工作，但同一顆
                         // 指紋要原封不動送下去重新武裝——連跳過都不能連
                         // 重新武裝一起跳過，否則這條鏈永久死掉。
-                        self.ec.sender().send_after(
-                            AppEvent::AutoFetchPoll { last_fingerprint },
+                        //
+                        // 走 `rearm` 而不是直接 `send_after`：倒數的 deadline
+                        // 必須跟著這一輪一起往後推。overlay 蓋著的時候狀態列
+                        // 本來就看不見，症狀要等 overlay 關掉才顯現——倒數卡在
+                        // `00:00` 一整個 interval，看起來像 auto-fetch 死了。
+                        auto_fetch::rearm(
+                            self.ec.sender(),
+                            self.ec.auto_fetch_clock(),
+                            last_fingerprint,
                             self.ctx.auto_fetch.interval,
                         );
                     } else {

--- a/src/app/status_line.rs
+++ b/src/app/status_line.rs
@@ -11,7 +11,9 @@ use ratatui::{
 
 use crate::{
     config::CursorType,
-    event::{AppEvent, CheckoutPickKind, RefCopyKind, RelatedItem, Sender, UserEvent},
+    event::{
+        AppEvent, AutoFetchClock, CheckoutPickKind, RefCopyKind, RelatedItem, Sender, UserEvent,
+    },
     github::{GhItemKind, MergeMethod, PrDraftAction, StateAction, StateFilter},
     view::View,
     widget::{h, hint_line, hint_pairs, keybind_hint_line, truncate_line, HintSpec},
@@ -200,15 +202,41 @@ pub(super) struct StatusLineState {
     line: StatusLine,
     ctx: Rc<AppContext>,
     tx: Sender,
+    /// 下一輪 auto-fetch 的 deadline，倒數用。在這裡持有而不是每次 render
+    /// 從 `App` 傳進來：`App::render` 對倒數沒有任何話語權，讓它收一個純轉手
+    /// 參數等於逼呼叫端知道一件與它無關的事。
+    auto_fetch_clock: AutoFetchClock,
 }
 
 impl StatusLineState {
-    pub(super) fn new(ctx: Rc<AppContext>, tx: Sender) -> Self {
+    pub(super) fn new(ctx: Rc<AppContext>, tx: Sender, auto_fetch_clock: AutoFetchClock) -> Self {
         Self {
             line: StatusLine::default(),
             ctx,
             tx,
+            auto_fetch_clock,
         }
+    }
+
+    /// 這一幀該顯示的倒數秒數。`None` = 沒開 auto-fetch、還沒排第一輪，或
+    /// 狀態列正被別的東西佔用。
+    ///
+    /// **重畫判斷（`App::run` 的 `Tick`）與實際繪製共用這一個函式**——兩邊
+    /// 各寫一次條件的話，顯示條件一改重畫條件就會默默不同步，變成開著
+    /// picker／輸入框時每秒白畫一次全螢幕（倒數那時根本沒顯示）。
+    ///
+    /// 取上界而不是截斷：`interval` 是 600 時，`arm` 當下的 remaining 是
+    /// 599.999，截斷的話永遠不會顯示 `10:00`，而且 `00:00` 會多停一整秒。
+    /// 取上界之後 `00:00` 精確等於「已過期 = worker 正在抓」。
+    pub(super) fn countdown_secs(&self) -> Option<u64> {
+        if !self.is_idle() {
+            return None;
+        }
+        self.auto_fetch_clock
+            .remaining()
+            // 先除再 cast：結果必定落在 u64 內，讀者不必回頭確認
+            // `as_millis()` 的 u128 上界。
+            .map(|d| d.as_millis().div_ceil(1000) as u64)
     }
 
     pub(super) fn open_ref_picker(&mut self, options: Vec<String>, kind: RefCopyKind) {
@@ -703,8 +731,32 @@ impl StatusLineState {
         }
     }
 
+    /// `nf-cod-git_fetch`（U+EC1D）+ 剩餘時間。
+    ///
+    /// 不足一分鐘印 `29s`，超過才印 `9:58`——`interval` 最小值是 30 秒，
+    /// 用固定 `mm:ss` 的話那一整段時間都在顯示一個恆為 `00:` 的前綴，是純
+    /// 噪音。帶 `s` 字尾讓「這是秒」不必靠上下文猜（少了 `:` 之後純數字會
+    /// 有歧義）。
+    ///
+    /// 分鐘數不補零：`interval` 在 CLI 與設定檔兩個入口都夾在 30–3600 秒，
+    /// 最寬就是 `60:00`。
+    ///
+    /// 沒有 Nerd Font 的終端會看到豆腐字——auto-fetch 本來就預設關閉、要明確
+    /// 開啟，不為此加一個顯示開關。
+    fn countdown_span(&self, secs: u64) -> Span<'static> {
+        let remaining = if secs < 60 {
+            format!("{secs}s")
+        } else {
+            format!("{}:{:02}", secs / 60, secs % 60)
+        };
+        Span::styled(
+            format!("\u{EC1D} {remaining}  "),
+            Style::default().fg(self.ctx.color_theme.status_input_transient_fg),
+        )
+    }
+
     pub(super) fn render(&self, f: &mut Frame, area: Rect, view: &View, numeric_prefix: &str) {
-        let text: Line = match &self.line {
+        let mut text: Line = match &self.line {
             StatusLine::None => {
                 if numeric_prefix.is_empty() {
                     build_hotkey_hints(view, &self.ctx)
@@ -795,6 +847,17 @@ impl StatusLineState {
                 .add_modifier(Modifier::BOLD)
                 .fg(self.ctx.color_theme.status_error_fg),
         };
+
+        // 插入點只有這一個，不在 match 的個別 arm 裡各插一次——要不要擴到
+        // 別的 variant（例如通知）是改 `countdown_secs` 那個述詞，不是回來
+        // 翻這裡的每一支。
+        //
+        // 上面幾支 `Line::raw(..).fg(..)` 的樣式是設在 *line* 上的，這個
+        // span 帶自己的 `fg`，不會被蓋掉也不會污染別人。
+        if let Some(secs) = self.countdown_secs() {
+            text.spans.insert(0, self.countdown_span(secs));
+        }
+
         let block = Block::default()
             .borders(Borders::TOP)
             .style(Style::default().fg(self.ctx.color_theme.divider_fg))
@@ -950,7 +1013,10 @@ mod tests {
 
     fn test_state() -> (StatusLineState, mpsc::Receiver<AppEvent>) {
         let (tx, rx) = Sender::channel_for_test();
-        (StatusLineState::new(test_ctx(), tx), rx)
+        (
+            StatusLineState::new(test_ctx(), tx, AutoFetchClock::default()),
+            rx,
+        )
     }
 
     fn char_key(c: char) -> KeyEvent {
@@ -1265,6 +1331,7 @@ mod tests {
                 line,
                 ctx: test_ctx(),
                 tx,
+                auto_fetch_clock: AutoFetchClock::default(),
             }
         }
 

--- a/src/auto_fetch.rs
+++ b/src/auto_fetch.rs
@@ -11,13 +11,17 @@
 //! GitHub API：不需要 token、無 rate limit、`upstream` 這類非 GitHub
 //! remote 也一起顧到。
 
-use std::{path::Path, process::Command, time::Duration};
+use std::{
+    path::Path,
+    process::Command,
+    time::{Duration, Instant},
+};
 
 use clap::ValueEnum;
 use serde::Deserialize;
 
 use crate::{
-    event::{AppEvent, EventController, PendingRefreshFlag, Sender},
+    event::{AppEvent, AutoFetchClock, EventController, PendingRefreshFlag, Sender},
     git::background_command,
     process::run_with_timeout,
 };
@@ -101,16 +105,24 @@ pub fn resolve(cli: AutoFetchOverrides, config: AutoFetchOverrides) -> AutoFetch
 pub fn spawn_poll(ec: &EventController, repo: &Path, last_fingerprint: String, interval: Duration) {
     let tx = ec.sender();
     let pending_refresh = ec.pending_refresh_flag();
+    let clock = ec.auto_fetch_clock();
     let repo = repo.to_path_buf();
     std::thread::spawn(move || {
         let next_fingerprint = poll_once(&tx, &pending_refresh, &repo, last_fingerprint);
-        tx.send_after(
-            AppEvent::AutoFetchPoll {
-                last_fingerprint: next_fingerprint,
-            },
-            interval,
-        );
+        rearm(tx, clock, next_fingerprint, interval);
     });
+}
+
+/// 排下一輪 poll，並把狀態列倒數的 deadline 對齊到同一個時間點。
+///
+/// 這兩件事必須成對——漏掉 `arm` 的話倒數會停在 `00:00` 直到下一輪真的
+/// 跑完。凡是用 `send_after` 排下一輪的都走這裡。
+///
+/// 收兩個把手而不是 `&EventController`：後者不是 `Send`，進不了 worker
+/// thread 的 `'static` closure（理由同 `PendingRefreshFlag`）。
+pub fn rearm(tx: Sender, clock: AutoFetchClock, last_fingerprint: String, interval: Duration) {
+    clock.arm(Instant::now() + interval);
+    tx.send_after(AppEvent::AutoFetchPoll { last_fingerprint }, interval);
 }
 
 /// 回傳值是「下一輪該拿去比對的指紋」——不是每次都等於新算出來的那個：

--- a/src/event.rs
+++ b/src/event.rs
@@ -377,6 +377,37 @@ impl PendingRefreshFlag {
     }
 }
 
+/// 下一輪 auto-fetch 的預定時間，狀態列的倒數讀它。
+///
+/// 跟 `PendingRefreshFlag` 同一種角色（`EventController` 內部狀態的輕量
+/// 把手），但存在這裡還有第二個、更硬的理由：`App` 每次 `AppEvent::Refresh`
+/// 都會被 `lib.rs::run()` 整個重建，watcher 一有動靜就發生。deadline 若存在
+/// `App` 欄位，每次重建就歸零，倒數會消失最長達一整個 interval。
+/// `EventController` 建在那個迴圈外面，跨重建存活。
+/// `Default` = 沒 arm 過，`remaining()` 恆為 `None`，語意等同「沒開
+/// auto-fetch」——不是危險狀態，所以對正式程式碼開放也無妨。
+#[derive(Debug, Clone, Default)]
+pub struct AutoFetchClock(Arc<Mutex<Option<Instant>>>);
+
+impl AutoFetchClock {
+    /// 排下一輪 poll 的同時呼叫——兩件事必須成對，見 `auto_fetch::rearm`。
+    pub fn arm(&self, at: Instant) {
+        *self.0.lock().unwrap() = Some(at);
+    }
+
+    /// `None` = 沒開 auto-fetch，或還沒排過第一輪。
+    ///
+    /// 已過期回 `Some(ZERO)`——`saturating_duration_since` 本來就是這個
+    /// 語意，不必手寫 `if at > now` 去製造特殊情況。過期期間正是 worker
+    /// 在跑 ls-remote／fetch 的時候，`00:00` 就是「正在抓」。
+    pub fn remaining(&self) -> Option<Duration> {
+        // 臨界區只做一次讀取，持鎖期間不呼叫任何東西——理由同
+        // `EventController` 對 mutex 中毒的註解。
+        let at = *self.0.lock().unwrap();
+        at.map(|at| at.saturating_duration_since(Instant::now()))
+    }
+}
+
 #[cfg(test)]
 impl Sender {
     pub(crate) fn channel_for_test() -> (Self, mpsc::Receiver<AppEvent>) {
@@ -412,6 +443,14 @@ pub struct EventController {
     /// 註解。無條件建好（不是 `Option`）：沒有 watcher 時這個 flag 只是沒人
     /// 讀，不是需要特判的錯誤狀態。
     pending_refresh: Arc<AtomicBool>,
+    /// 下一輪 auto-fetch 的預定時間，狀態列倒數用。無條件建好：沒開
+    /// auto-fetch 時只是沒人 `arm`，`remaining()` 恆為 `None`，不是需要
+    /// 特判的狀態。見 `AutoFetchClock`。
+    ///
+    /// 直接存 newtype 而不是裸 `Arc`（`pending_refresh` 那樣）——
+    /// `PendingRefreshFlag` 不是 `Clone`，只能存裸的再包；`AutoFetchClock`
+    /// 是，沒有同一個限制。
+    auto_fetch_clock: AutoFetchClock,
     term_signal: Arc<AtomicBool>,
     heartbeat: Arc<AtomicU64>,
 }
@@ -460,6 +499,7 @@ impl EventController {
             stop: Arc::new(AtomicBool::new(false)),
             handle: Arc::new(Mutex::new(None)),
             pending_refresh: Arc::new(AtomicBool::new(false)),
+            auto_fetch_clock: AutoFetchClock::default(),
             term_signal,
             heartbeat: Arc::new(AtomicU64::new(0)),
         };
@@ -648,6 +688,12 @@ impl EventController {
     /// `PendingRefreshFlag` 文件。
     pub fn pending_refresh_flag(&self) -> PendingRefreshFlag {
         PendingRefreshFlag(self.pending_refresh.clone())
+    }
+
+    /// 狀態列倒數與 auto-fetch worker 共用的 deadline 把手，見
+    /// `AutoFetchClock` 文件。
+    pub fn auto_fetch_clock(&self) -> AutoFetchClock {
+        self.auto_fetch_clock.clone()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use std::{
     io::{IsTerminal, Write},
     path::Path,
     rc::Rc,
+    time::Instant,
 };
 
 use app::{App, Ret};
@@ -603,6 +604,15 @@ pub fn run() -> Result<()> {
     // `is_inside_work_tree` 當閘門——bare repo 沒有 worktree 但照樣有
     // remote、照樣該 auto-fetch。
     if auto_fetch_settings.mode == AutoFetch::On {
+        // 倒數的 deadline 設在「現在」，狀態列從第一幀就顯示 `00:00`——語意
+        // 是「正在抓」，跟中途任何一輪 worker 執行期間看到的完全一致。不設
+        // 的話，從啟動到第一輪 worker 跑完為止（ls-remote 與 fetch 的逾時
+        // 預算加起來最壞 70 秒以上）狀態列是空的，而「開起來就看得到它在
+        // 跑」正是這個倒數存在的理由。
+        //
+        // 這一發是立即送、不是 `send_after`，所以不走 `auto_fetch::rearm`
+        // ——為了消滅一個分支去動啟動時的事件順序不划算。
+        ec.auto_fetch_clock().arm(Instant::now());
         ec.sender().send(event::AppEvent::AutoFetchPoll {
             last_fingerprint: String::new(),
         });


### PR DESCRIPTION
## 變更摘要

- 狀態列最左邊顯示距離下一輪 auto-fetch 的剩餘時間，配 nf-cod-git_fetch 圖示；不足一分鐘印 `29s`，超過才印 `9:58`——interval 最小值是 30 秒，固定 mm:ss 會讓那整段時間都在顯示恆為 `00:` 的前綴
- 只在閒置（`StatusLine::None`）時顯示，輸入框／picker／通知出現時讓位，不擠掉內容也不影響輸入框的游標座標計算
- deadline 存在 `EventController` 而非 `App`：`App` 每次 `AppEvent::Refresh` 都會被重建，存在 `App` 欄位的話 watcher 一觸發倒數就歸零
- `Tick` 改以「該顯示的秒數變了」為重畫條件，重畫判斷與繪製共用 `countdown_secs()` 這一個述詞，兩邊各寫一次會在非閒置時每秒白畫一次全螢幕
- 新增 `auto_fetch::rearm()` 收攏「排下一輪 poll」與「對齊 deadline」的成對不變式，補上 `app.rs` 有 blocking overlay 時的跳過路徑（原本不經過 `spawn_poll`，會讓倒數卡在 `0s` 一整個 interval）

Refs #88

> base 是 `26082217` 而非 `main`，GitHub 的 `Closes` 只在併入預設分支時生效，所以這裡用 `Refs`；issue #88 待這條線併回 `main` 後再關。

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test` 通過（599 passed, 0 failed）