### PR TITLE
feat: PR preview 顯示 review 留言（總結與行內） (#94)

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use std::sync::{LazyLock, Mutex, MutexGuard};
 use std::time::Duration;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Deserializer};
 
 use crate::process::run_with_timeout;
@@ -349,6 +349,13 @@ struct GqlIssueNode {
 struct GqlConnection<T> {
     nodes: Vec<T>,
 }
+/// 手寫而非 `#[derive(Default)]`：derive 會加上多餘的 `T: Default` bound，
+/// 但一個空 `Vec<T>` 從不需要 `T` 本身可以是預設值。
+impl<T> Default for GqlConnection<T> {
+    fn default() -> Self {
+        GqlConnection { nodes: Vec::new() }
+    }
+}
 
 impl GqlIssueNode {
     fn into_gh_issue(self) -> GhIssue {
@@ -511,8 +518,21 @@ pub enum GhTimelineItem {
     PullRequestCommit {
         commit: GhCommit,
     },
-    /// `itemTypes` 理論上只會產生上面兩種 variant，但把整頁的反序列化都賭在
-    /// GitHub 永遠不會新增第三種上並不值得 —— 否則一個未知的 `__typename` 會讓
+    PullRequestReview {
+        #[serde(default)]
+        state: String,
+        #[serde(default)]
+        body: String,
+        /// PENDING（尚未 submit 的草稿，只有作者自己看得到）時是 `None`——
+        /// 過濾靠這個欄位，不比對 `state` 字串。
+        #[serde(default, rename = "submittedAt")]
+        submitted_at: Option<String>,
+        author: Option<GhAuthor>,
+        #[serde(default)]
+        comments: GhReviewCommentConn,
+    },
+    /// `itemTypes` 理論上只會產生上面三種 variant，但把整頁的反序列化都賭在
+    /// GitHub 永遠不會新增第四種上並不值得 —— 否則一個未知的 `__typename` 會讓
     /// 每個 node 都失敗，而不只是這一個。
     #[serde(other)]
     Unknown,
@@ -531,6 +551,39 @@ pub struct GhCommit {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct GhStatusCheckRollup {
     pub state: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GhReviewCommentConn {
+    #[serde(default)]
+    pub total_count: usize,
+    #[serde(default)]
+    pub nodes: Vec<GhReviewComment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GhReviewComment {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub path: String,
+    /// 留言所在行被後續 commit 改掉時是 `None`（PR 一 rebase 就常見）；
+    /// `parse_timeline_graphql` 會 fallback 到 `original_line`，所以
+    /// view 層看到的已經是收斂後的單一 `Option<u32>`。
+    #[serde(default)]
+    pub line: Option<u32>,
+    #[serde(default, rename = "originalLine")]
+    pub original_line: Option<u32>,
+    #[serde(default)]
+    pub outdated: bool,
+    #[serde(default)]
+    pub body: String,
+    /// 是否已標記解決——GraphQL 本身不在這個型別上提供，是
+    /// `parse_timeline_graphql` 拿同一次查詢多帶的 `reviewThreads` 回填的。
+    #[serde(default)]
+    pub resolved: bool,
 }
 
 /// PR 目前是否可以合併。`UNKNOWN`（GitHub 惰性計算出的第三種狀態，
@@ -565,16 +618,29 @@ pub struct GhTimelinePage {
 /// PullRequestCommit can't be spread inside IssueTimelineItems"），而不是安靜地
 /// 回傳空結果 —— 所以四處分岔綁在同一個 match 上，漏掉其中一項就編不過。
 fn build_timeline_query(kind: GhItemKind) -> String {
-    let (item_field, item_types, mergeable_field, commit_fragment) = match kind {
+    let (item_field, item_types, pr_only_fields, pr_fragments) = match kind {
         GhItemKind::Issue => ("issue", "ISSUE_COMMENT", "", ""),
         GhItemKind::PullRequest => (
             "pullRequest",
-            "ISSUE_COMMENT, PULL_REQUEST_COMMIT",
-            "mergeable",
+            "ISSUE_COMMENT, PULL_REQUEST_COMMIT, PULL_REQUEST_REVIEW",
+            // reviewThreads 是 resolved 狀態唯一的來源——`PullRequestReviewComment`
+            // 本身沒有這個欄位，只在 `PullRequestReviewThread` 上。跟 timelineItems
+            // 平行查詢，回應裡靠 comment id 對應回去（見 parse_timeline_graphql）。
+            r#"mergeable
+                    reviewThreads(first:100) {
+                        nodes { isResolved comments(first:20) { nodes { id } } }
+                    }"#,
             r#"... on PullRequestCommit { commit {
                                 abbreviatedOid messageHeadline
                                 statusCheckRollup { state }
-                            } }"#,
+                            } }
+                            ... on PullRequestReview {
+                                state body submittedAt author { login }
+                                comments(first:20) {
+                                    totalCount
+                                    nodes { id path line originalLine outdated body }
+                                }
+                            }"#,
         ),
     };
     // 用 100（connection 上限）而非 50：commit 只佔一行視覺高度，
@@ -583,13 +649,13 @@ fn build_timeline_query(kind: GhItemKind) -> String {
         r#"query($owner:String!,$name:String!,$number:Int!,$after:String){{
             repository(owner:$owner,name:$name){{
                 {item_field}(number:$number){{
-                    {mergeable_field}
+                    {pr_only_fields}
                     timelineItems(first:100,after:$after,itemTypes:[{item_types}]){{
                         pageInfo {{ hasNextPage endCursor }}
                         nodes {{
                             __typename
                             ... on IssueComment {{ body createdAt author {{ login }} }}
-                            {commit_fragment}
+                            {pr_fragments}
                         }}
                     }}
                 }}
@@ -639,8 +705,21 @@ fn parse_timeline_graphql(json: &str, kind: GhItemKind) -> Result<GhTimelinePage
     } else {
         None
     };
+    // resolved 狀態與 line/originalLine 的收斂都在這裡做一次，view 層因此
+    // 只需要認識收斂後的單一 `Option<u32>` 與 `bool`，不必知道 reviewThreads
+    // 這條平行查詢的存在。
+    let resolved_ids = resolved_comment_ids(&container.review_threads);
+    let mut items = conn.nodes;
+    for item in &mut items {
+        if let GhTimelineItem::PullRequestReview { comments, .. } = item {
+            for c in &mut comments.nodes {
+                c.line = c.line.or(c.original_line);
+                c.resolved = resolved_ids.contains(c.id.as_str());
+            }
+        }
+    }
     Ok(GhTimelinePage {
-        items: conn.nodes,
+        items,
         next_cursor,
         mergeable: container.mergeable.as_deref().and_then(Mergeable::from_api),
     })
@@ -668,6 +747,8 @@ struct GqlTimelineContainer {
     #[serde(default)]
     mergeable: Option<String>,
     timeline_items: GqlTimelineConn,
+    #[serde(default)]
+    review_threads: GqlConnection<GqlReviewThread>,
 }
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -675,6 +756,31 @@ struct GqlTimelineConn {
     #[serde(default)]
     page_info: GqlPageInfo,
     nodes: Vec<GhTimelineItem>,
+}
+
+/// resolved 狀態不在 `PullRequestReviewComment` 上，只在
+/// `PullRequestReviewThread` 上——這裡把已 resolved 的 thread 底下每則
+/// 留言的 id 收集起來，讓 `parse_timeline_graphql` 拿去回填。
+fn resolved_comment_ids(threads: &GqlConnection<GqlReviewThread>) -> FxHashSet<&str> {
+    threads
+        .nodes
+        .iter()
+        .filter(|t| t.is_resolved)
+        .flat_map(|t| t.comments.nodes.iter().map(|c| c.id.as_str()))
+        .collect()
+}
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GqlReviewThread {
+    #[serde(default)]
+    is_resolved: bool,
+    #[serde(default)]
+    comments: GqlConnection<GqlReviewThreadCommentId>,
+}
+#[derive(Deserialize)]
+struct GqlReviewThreadCommentId {
+    #[serde(default)]
+    id: String,
 }
 
 // ── Checkbox／工作清單 ──
@@ -1347,12 +1453,18 @@ mod tests {
         assert!(!q.contains("PullRequestCommit"));
         assert!(!q.contains("PULL_REQUEST_COMMIT"));
         assert!(!q.contains("mergeable"));
+        assert!(!q.contains("PullRequestReview"));
+        assert!(!q.contains("PULL_REQUEST_REVIEW"));
+        assert!(!q.contains("reviewThreads"));
 
         let q = build_timeline_query(GhItemKind::PullRequest);
         assert!(q.contains("pullRequest(number:$number)"));
         assert!(q.contains("PullRequestCommit"));
         assert!(q.contains("PULL_REQUEST_COMMIT"));
         assert!(q.contains("mergeable"));
+        assert!(q.contains("PullRequestReview"));
+        assert!(q.contains("PULL_REQUEST_REVIEW"));
+        assert!(q.contains("reviewThreads"));
     }
 
     /// `itemTypes` 理論上只會產生兩種已知的 variant，但這個測試釘住了
@@ -1384,5 +1496,99 @@ mod tests {
         assert_eq!(page.items.len(), 2);
         assert!(matches!(page.items[0], GhTimelineItem::Unknown));
         assert!(matches!(page.items[1], GhTimelineItem::IssueComment { .. }));
+    }
+
+    /// resolved 狀態不在 `PullRequestReviewComment` 上，是這裡拿平行查詢的
+    /// `reviewThreads` 靠 comment id 回填的。一個 review 帶兩則行內留言，
+    /// 只有其中一個的 id 出現在已 resolved 的 thread 裡。
+    #[test]
+    fn parse_timeline_backfills_resolved_from_review_threads() {
+        let json = r#"{
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "mergeable": "MERGEABLE",
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "isResolved": true,
+                                    "comments": { "nodes": [{"id": "C1"}] }
+                                },
+                                {
+                                    "isResolved": false,
+                                    "comments": { "nodes": [{"id": "C2"}] }
+                                }
+                            ]
+                        },
+                        "timelineItems": {
+                            "pageInfo": {"hasNextPage": false, "endCursor": null},
+                            "nodes": [
+                                {
+                                    "__typename": "PullRequestReview",
+                                    "state": "COMMENTED",
+                                    "body": "",
+                                    "submittedAt": "2026-01-01T00:00:00Z",
+                                    "author": {"login": "carol"},
+                                    "comments": {
+                                        "totalCount": 2,
+                                        "nodes": [
+                                            {"id": "C1", "path": "a.rs", "line": 5, "originalLine": 5, "outdated": false, "body": "x"},
+                                            {"id": "C2", "path": "b.rs", "line": 9, "originalLine": 9, "outdated": false, "body": "y"}
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+        let page = parse_timeline_graphql(json, GhItemKind::PullRequest).unwrap();
+        let GhTimelineItem::PullRequestReview { comments, .. } = &page.items[0] else {
+            panic!("expected a review item, got {:?}", page.items[0]);
+        };
+        assert!(comments.nodes[0].resolved, "C1's thread is resolved");
+        assert!(!comments.nodes[1].resolved, "C2's thread is not resolved");
+    }
+
+    /// `line` 為 null（留言所在行被後續 commit 改掉）時 fallback 到
+    /// `originalLine`；兩者皆 null 時保持 `None`，view 層只印 path。
+    #[test]
+    fn parse_timeline_falls_back_to_original_line_when_line_is_null() {
+        let json = r#"{
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "mergeable": null,
+                        "reviewThreads": { "nodes": [] },
+                        "timelineItems": {
+                            "pageInfo": {"hasNextPage": false, "endCursor": null},
+                            "nodes": [
+                                {
+                                    "__typename": "PullRequestReview",
+                                    "state": "COMMENTED",
+                                    "body": "",
+                                    "submittedAt": "2026-01-01T00:00:00Z",
+                                    "author": {"login": "carol"},
+                                    "comments": {
+                                        "totalCount": 2,
+                                        "nodes": [
+                                            {"id": "C1", "path": "a.rs", "line": null, "originalLine": 5, "outdated": true, "body": "x"},
+                                            {"id": "C2", "path": "b.rs", "line": null, "originalLine": null, "outdated": true, "body": "y"}
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+        let page = parse_timeline_graphql(json, GhItemKind::PullRequest).unwrap();
+        let GhTimelineItem::PullRequestReview { comments, .. } = &page.items[0] else {
+            panic!("expected a review item, got {:?}", page.items[0]);
+        };
+        assert_eq!(comments.nodes[0].line, Some(5));
+        assert_eq!(comments.nodes[1].line, None);
     }
 }

--- a/src/view/github/mod.rs
+++ b/src/view/github/mod.rs
@@ -32,6 +32,7 @@ enum Section {
     Body,
     Comment,
     Commit,
+    Review,
 }
 
 impl Section {
@@ -41,6 +42,7 @@ impl Section {
             Section::Body => Color::Indexed(146),    // 粉藍灰 (#afafd7)
             Section::Comment => Color::Indexed(151), // 粉綠灰 (#afd7af)
             Section::Commit => Color::Indexed(186),  // 粉黃灰 (#d7d787)
+            Section::Review => Color::Indexed(181),  // 粉紅灰 (#d7afaf)
         }
     }
 
@@ -903,7 +905,10 @@ mod tests {
     use super::*;
     use ratatui::{backend::TestBackend, Terminal};
 
-    use crate::github::{GhAuthor, GhCommit, GhStatusCheckRollup, GhTimelineItem, Mergeable};
+    use crate::github::{
+        GhAuthor, GhCommit, GhReviewComment, GhReviewCommentConn, GhStatusCheckRollup,
+        GhTimelineItem, Mergeable,
+    };
 
     use super::preview::build_preview_content;
 
@@ -1142,6 +1147,41 @@ mod tests {
                     state: state.to_string(),
                 }),
             },
+        }
+    }
+
+    /// `submitted_at: None` 代表 PENDING（尚未送出的草稿），會被
+    /// `TimelineBlock::from_gh` 過濾掉——測試 PENDING 過濾時傳 `None`。
+    fn timeline_review(
+        login: &str,
+        state: &str,
+        submitted_at: Option<&str>,
+        body: &str,
+        comments: Vec<GhReviewComment>,
+    ) -> GhTimelineItem {
+        GhTimelineItem::PullRequestReview {
+            state: state.to_string(),
+            body: body.to_string(),
+            submitted_at: submitted_at.map(str::to_string),
+            author: Some(GhAuthor {
+                login: login.to_string(),
+            }),
+            comments: GhReviewCommentConn {
+                total_count: comments.len(),
+                nodes: comments,
+            },
+        }
+    }
+
+    fn review_comment(path: &str, line: Option<u32>, body: &str) -> GhReviewComment {
+        GhReviewComment {
+            id: format!("{path}:{line:?}"),
+            path: path.to_string(),
+            line,
+            original_line: line,
+            outdated: false,
+            body: body.to_string(),
+            resolved: false,
         }
     }
 
@@ -1502,6 +1542,229 @@ mod tests {
                 ('─', Some(Section::Comment.color())),
             ],
         );
+    }
+
+    /// block 分隔線的顏色——markdown 自己那條固定 DarkGray 的不算，
+    /// 那條不是 `append_comment_lines` 畫的。
+    fn block_divider_colors(lines: &[Line<'static>]) -> Vec<Option<Color>> {
+        lines
+            .iter()
+            .filter(|l| {
+                let text: String = l.spans.iter().map(|s| s.content.to_string()).collect();
+                text.starts_with('─') && l.style.fg != Some(Color::DarkGray)
+            })
+            .map(|l| l.style.fg)
+            .collect()
+    }
+
+    /// 分隔線顏色來自它*之前*那個 block 的 section，所以 `Section::Review`
+    /// 的顏色要在 review block *之後*還有其他 block 時才會被畫出來。
+    #[test]
+    fn review_block_divider_is_colour_coded() {
+        let mut view = view_with_body("body".to_string());
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(
+                vec![
+                    timeline_comment("a", "one"),
+                    timeline_review(
+                        "reviewer",
+                        "APPROVED",
+                        Some("2026-08-30T12:00:00Z"),
+                        "lgtm",
+                        Vec::new(),
+                    ),
+                    timeline_comment("b", "two"),
+                ],
+                None,
+            ),
+        );
+
+        let (lines, _) = build_preview_content(&view.preview_input(40));
+        assert_eq!(
+            block_divider_colors(&lines),
+            vec![
+                Some(Section::Body.color()),    // body → 第一則留言
+                Some(Section::Comment.color()), // 第一則留言 → review block
+                Some(Section::Review.color()),  // review block → 第二則留言
+            ],
+            "got:\n{lines:?}"
+        );
+    }
+
+    /// 一則 review 連同它的行內留言只算*一個* block：只有一條 Review 色
+    /// 分隔線，行內留言之間不會各自被切成獨立 block（那樣會多出好幾條
+    /// 分隔線，把「這些留言屬於同一次 review」的關係拆散）。
+    #[test]
+    fn review_and_its_inline_comments_render_as_one_block() {
+        let mut view = view_with_body("body".to_string());
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(
+                vec![timeline_review(
+                    "reviewer",
+                    "APPROVED",
+                    Some("2026-08-30T12:00:00Z"),
+                    "looks good",
+                    vec![
+                        review_comment("src/a.rs", Some(10), "nit here"),
+                        review_comment("src/b.rs", Some(20), "and here"),
+                    ],
+                )],
+                None,
+            ),
+        );
+
+        // 分隔線的顏色來自它*之前*那個 block 的 section（見
+        // `dividers_are_colour_coded_by_section`），這裡唯一的 block 前面
+        // 是初始值 `Section::Body`，所以直接數「不是 markdown 自己那條
+        // 固定 DarkGray 分隔線」的數量——一個 block 只會有一條。
+        let (lines, _) = build_preview_content(&view.preview_input(40));
+        let block_dividers = block_divider_colors(&lines).len();
+        assert_eq!(
+            block_dividers, 1,
+            "review + its inline comments must draw exactly one divider, got:\n{lines:?}"
+        );
+    }
+
+    #[test]
+    fn approved_review_renders_marker_author_state_and_body() {
+        let mut view = view_with_body("body".to_string());
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(
+                vec![timeline_review(
+                    "reviewer",
+                    "APPROVED",
+                    Some("2026-08-30T12:00:00Z"),
+                    "looks good",
+                    Vec::new(),
+                )],
+                None,
+            ),
+        );
+
+        let screen = render_to_string(&mut view);
+        assert!(screen.contains('✓'), "got:\n{screen}");
+        assert!(screen.contains("@reviewer"), "got:\n{screen}");
+        assert!(screen.contains("approved"), "got:\n{screen}");
+        assert!(screen.contains("looks good"), "got:\n{screen}");
+    }
+
+    #[test]
+    fn inline_comment_renders_path_and_line() {
+        let mut view = view_with_body("body".to_string());
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(
+                vec![timeline_review(
+                    "reviewer",
+                    "COMMENTED",
+                    Some("2026-08-30T12:00:00Z"),
+                    "",
+                    vec![review_comment(
+                        "src/github.rs",
+                        Some(604),
+                        "missing a type here",
+                    )],
+                )],
+                None,
+            ),
+        );
+
+        let screen = render_to_string(&mut view);
+        assert!(screen.contains("src/github.rs:604"), "got:\n{screen}");
+        assert!(screen.contains("missing a type here"), "got:\n{screen}");
+    }
+
+    /// PENDING review（`submitted_at: None`，尚未送出的草稿）要被過濾掉；
+    /// 一頁*只有* PENDING review 時仍要 fallback 到 `(no comments)`，跟
+    /// 全 `Unknown` 節點是同一種情況。
+    #[test]
+    fn pending_review_is_filtered_and_falls_back_to_no_comments() {
+        let mut view = view_with_body("body".to_string());
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(
+                vec![timeline_review(
+                    "reviewer",
+                    "PENDING",
+                    None,
+                    "draft, not submitted yet",
+                    Vec::new(),
+                )],
+                None,
+            ),
+        );
+
+        let screen = render_to_string(&mut view);
+        assert!(
+            !screen.contains("draft, not submitted yet"),
+            "PENDING review draft must not render, got:\n{screen}"
+        );
+        assert!(screen.contains("no comments"), "got:\n{screen}");
+    }
+
+    #[test]
+    fn resolved_and_outdated_markers_appear_on_inline_comments() {
+        let mut view = view_with_body("body".to_string());
+        let mut resolved = review_comment("src/a.rs", Some(1), "fixed already");
+        resolved.resolved = true;
+        resolved.outdated = true;
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(
+                vec![timeline_review(
+                    "reviewer",
+                    "COMMENTED",
+                    Some("2026-08-30T12:00:00Z"),
+                    "",
+                    vec![resolved],
+                )],
+                None,
+            ),
+        );
+
+        let screen = render_to_string(&mut view);
+        assert!(screen.contains("(resolved)"), "got:\n{screen}");
+        assert!(screen.contains("(outdated)"), "got:\n{screen}");
+    }
+
+    #[test]
+    fn review_comment_overflow_shows_remaining_count() {
+        let mut view = view_with_body("body".to_string());
+        let mut review = timeline_review(
+            "reviewer",
+            "COMMENTED",
+            Some("2026-08-30T12:00:00Z"),
+            "",
+            vec![review_comment("src/a.rs", Some(1), "one")],
+        );
+        // totalCount 比實際帶回的 nodes 多——GraphQL 端只給了前 N 則。
+        if let GhTimelineItem::PullRequestReview { comments, .. } = &mut review {
+            comments.total_count = 4;
+        }
+        view.append_timeline_items(
+            1,
+            GhItemKind::PullRequest,
+            None,
+            timeline_page(vec![review], None),
+        );
+
+        let screen = render_to_string(&mut view);
+        assert!(screen.contains("(+3 more comments)"), "got:\n{screen}");
     }
 
     /// commit 集中成一個區塊：即使 API 回傳的時間序是 commit/comment 交錯，

--- a/src/view/github/timeline.rs
+++ b/src/view/github/timeline.rs
@@ -45,6 +45,81 @@ pub(super) struct TimelineBlock<'a> {
     pub(super) items: Vec<TimelineItem<'a>>,
 }
 
+impl<'a> TimelineBlock<'a> {
+    /// 一個 gh timeline node 對應 0 或 1 個 block。`Unknown` 節點——`itemTypes`
+    /// 本不該產生的 `__typename`——被直接丟棄，不渲染成錯誤：一個無法辨識的
+    /// 節點不該在原本正常的 timeline 中間跳出一則嚇人的訊息。PENDING review
+    /// （`submitted_at` 為 `None`，尚未送出的草稿，只有作者自己看得到）同樣
+    /// 丟棄，理由相同——不該讓半成品永遠掛在別人也看得到的 timeline 上。
+    ///
+    /// 一則 review 連同它的行內留言算*一個* block：`TimelineBlock` 的用途
+    /// 就是「同一個 section 底下連續出現的 item」，行內留言緊接在總結留言
+    /// 之後正是這個形狀，不需要為此另立機制。
+    fn from_gh(item: &'a GhTimelineItem) -> Option<Self> {
+        match item {
+            GhTimelineItem::IssueComment {
+                body,
+                created_at,
+                author,
+            } => Some(TimelineBlock {
+                section: Section::Comment,
+                items: vec![TimelineItem::Comment {
+                    author: author.as_ref().map_or("ghost", |a| a.login.as_str()),
+                    created_at,
+                    body,
+                }],
+            }),
+            GhTimelineItem::PullRequestCommit { commit } => Some(TimelineBlock {
+                section: Section::Commit,
+                items: vec![TimelineItem::Commit {
+                    oid: &commit.abbreviated_oid,
+                    headline: &commit.message_headline,
+                    ci_state: commit
+                        .status_check_rollup
+                        .as_ref()
+                        .map(|r| r.state.as_str()),
+                }],
+            }),
+            GhTimelineItem::PullRequestReview {
+                state,
+                body,
+                submitted_at,
+                author,
+                comments,
+            } => {
+                let submitted_at = submitted_at.as_deref()?;
+                let mut items = vec![TimelineItem::Review {
+                    state,
+                    author: author.as_ref().map_or("ghost", |a| a.login.as_str()),
+                    submitted_at,
+                    body,
+                }];
+                items.extend(comments.nodes.iter().map(|c| TimelineItem::ReviewComment {
+                    path: &c.path,
+                    line: c.line,
+                    outdated: c.outdated,
+                    resolved: c.resolved,
+                    body: &c.body,
+                }));
+                if comments.total_count > comments.nodes.len() {
+                    items.push(TimelineItem::notice(
+                        format!(
+                            "(+{} more comments)",
+                            comments.total_count - comments.nodes.len()
+                        ),
+                        Color::DarkGray,
+                    ));
+                }
+                Some(TimelineBlock {
+                    section: Section::Review,
+                    items,
+                })
+            }
+            GhTimelineItem::Unknown => None,
+        }
+    }
+}
+
 /// 把 `TimelineEntry` 可能處於的每種狀態——pending、failed、loaded（空或
 /// 非空）、分頁中——攤平成一份可渲染 block 的清單。走訪結果的渲染迴圈本身
 /// 沒有任何分支：「我現在是什麼狀態」這個問題只在這裡回答一次。
@@ -68,28 +143,27 @@ pub(super) fn build_timeline(
             vec![notice_block(format!("(comments failed: {e})"), Color::Red)]
         }
         TimelineLoad::Loaded => {
-            let (commits, comments): (Vec<_>, Vec<_>) = entry
+            let (commit_blocks, rest): (Vec<_>, Vec<_>) = entry
                 .items
                 .iter()
-                .filter_map(TimelineItem::from_gh)
-                .partition(|item| matches!(item, TimelineItem::Commit { .. }));
+                .filter_map(TimelineBlock::from_gh)
+                .partition(|b| b.section == Section::Commit);
 
             let mut blocks = Vec::new();
-            if !commits.is_empty() {
+            if !commit_blocks.is_empty() {
+                let commit_items: Vec<_> =
+                    commit_blocks.into_iter().flat_map(|b| b.items).collect();
                 let items = if expand_commits {
-                    commits
+                    commit_items
                 } else {
-                    vec![TimelineItem::CollapsedCommits(commits.len())]
+                    vec![TimelineItem::CollapsedCommits(commit_items.len())]
                 };
                 blocks.push(TimelineBlock {
                     section: Section::Commit,
                     items,
                 });
             }
-            blocks.extend(comments.into_iter().map(|item| TimelineBlock {
-                section: Section::Comment,
-                items: vec![item],
-            }));
+            blocks.extend(rest);
 
             // 判斷用的是*過濾/分組後*的 block 清單，不是 `entry.items`：一頁
             // 全是 `Unknown` 節點時，仍然要 fallback 到提示訊息，而不是渲染
@@ -140,8 +214,9 @@ pub(super) fn commit_block_height(items: &[GhTimelineItem], expand_commits: bool
     }
 }
 
-/// timeline 的一列可渲染內容：留言、commit、收合後的 commit 數量摘要，
-/// 或是代替以上任何一種的狀態提示（載入中／錯誤／空／分頁 footer）。
+/// timeline 的一列可渲染內容：留言、commit、review 總結、review 行內留言、
+/// 收合後的 commit 數量摘要，或是代替以上任何一種的狀態提示
+/// （載入中／錯誤／空／分頁 footer）。
 /// 借用自建置它的那個 `TimelineEntry`——每次 cache miss 都會從頭重建，
 /// 所以渲染之後不需要保留任何東西。
 pub(super) enum TimelineItem<'a> {
@@ -156,38 +231,27 @@ pub(super) enum TimelineItem<'a> {
         ci_state: Option<&'a str>,
     },
     CollapsedCommits(usize),
+    Review {
+        state: &'a str,
+        author: &'a str,
+        submitted_at: &'a str,
+        body: &'a str,
+    },
+    /// 前面必定緊接著同一個 block 裡的 `Review`（或另一個 `ReviewComment`）
+    /// ——渲染時自帶一條前置空行當視覺分隔，見 `render`。
+    ReviewComment {
+        path: &'a str,
+        line: Option<u32>,
+        outdated: bool,
+        resolved: bool,
+        body: &'a str,
+    },
     Notice(Line<'static>),
 }
 
 impl<'a> TimelineItem<'a> {
     fn notice(text: impl Into<String>, color: Color) -> Self {
         TimelineItem::Notice(Line::styled(text.into(), Style::default().fg(color)))
-    }
-
-    /// `Unknown` 節點——`itemTypes` 本不該產生的 `__typename`——會被直接
-    /// 丟棄，而不是渲染成錯誤。一個無法辨識的節點不該在原本正常的
-    /// timeline 中間跳出一則嚇人的訊息。
-    fn from_gh(item: &'a GhTimelineItem) -> Option<Self> {
-        match item {
-            GhTimelineItem::IssueComment {
-                body,
-                created_at,
-                author,
-            } => Some(TimelineItem::Comment {
-                author: author.as_ref().map_or("ghost", |a| a.login.as_str()),
-                created_at,
-                body,
-            }),
-            GhTimelineItem::PullRequestCommit { commit } => Some(TimelineItem::Commit {
-                oid: &commit.abbreviated_oid,
-                headline: &commit.message_headline,
-                ci_state: commit
-                    .status_check_rollup
-                    .as_ref()
-                    .map(|r| r.state.as_str()),
-            }),
-            GhTimelineItem::Unknown => None,
-        }
     }
 
     pub(super) fn render(self, lines: &mut Vec<Line<'static>>, width: usize) {
@@ -224,8 +288,68 @@ impl<'a> TimelineItem<'a> {
                     Style::default().fg(Color::DarkGray),
                 ));
             }
+            TimelineItem::Review {
+                state,
+                author,
+                submitted_at,
+                body,
+            } => {
+                let (marker, marker_color) = review_state_marker(state);
+                lines.push(Line::from(vec![
+                    Span::styled(marker, Style::default().fg(marker_color)),
+                    Span::styled(
+                        format!("@{author}"),
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        format!("  {}", state.to_lowercase()),
+                        Style::default().fg(marker_color),
+                    ),
+                    Span::styled(
+                        format!("  {submitted_at}"),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]));
+                lines.extend(crate::view::markdown::render(body, width));
+            }
+            TimelineItem::ReviewComment {
+                path,
+                line,
+                outdated,
+                resolved,
+                body,
+            } => {
+                lines.push(Line::raw(""));
+                let mut header = match line {
+                    Some(l) => format!("{path}:{l}"),
+                    None => path.to_string(),
+                };
+                if outdated {
+                    header.push_str("  (outdated)");
+                }
+                if resolved {
+                    header.push_str("  (resolved)");
+                }
+                lines.push(Line::styled(header, Style::default().fg(Color::DarkGray)));
+                lines.extend(crate::view::markdown::render(body, width));
+            }
             TimelineItem::Notice(line) => lines.push(line),
         }
+    }
+}
+
+/// review 總結留言 state 的標記字元 + 顏色。完全沒有對應狀態時 fallback
+/// 成兩個空格，讓 `@author` 欄位跟其他 review 保持對齊——理由同
+/// `commit_ci_marker`。
+fn review_state_marker(state: &str) -> (&'static str, Color) {
+    match state {
+        "APPROVED" => ("✓ ", Color::Green),
+        "CHANGES_REQUESTED" => ("✗ ", Color::Red),
+        "COMMENTED" => ("● ", Color::Blue),
+        "DISMISSED" => ("- ", Color::DarkGray),
+        _ => ("  ", Color::DarkGray),
     }
 }
 
@@ -302,6 +426,17 @@ mod tests {
         // 完全沒有 rollup（API 回傳 null）：用兩個空格，而不是讓標記欄位
         // 直接消失，這樣 oid 在各個 commit 之間才能保持對齊。
         assert_eq!(commit_ci_marker(None).0, "  ");
+    }
+
+    #[test]
+    fn review_state_marker_covers_all_states() {
+        assert_eq!(review_state_marker("APPROVED").0, "✓ ");
+        assert_eq!(review_state_marker("CHANGES_REQUESTED").0, "✗ ");
+        assert_eq!(review_state_marker("COMMENTED").0, "● ");
+        assert_eq!(review_state_marker("DISMISSED").0, "- ");
+        // 未知 state（理論上不會發生，但 fallback 用兩個空格保持 @author
+        // 欄位跟其他 review 對齊，而不是讓標記欄位消失。
+        assert_eq!(review_state_marker("PENDING").0, "  ");
     }
 
     #[test]


### PR DESCRIPTION
## 變更摘要

- GraphQL timeline query 多接 `PULL_REQUEST_REVIEW`，並平行查詢 `reviewThreads` 取得行內留言的 resolved 狀態
- `TimelineItem` 新增 `Review` / `ReviewComment` 兩個扁平 variant，一則 review 連同它的行內留言共用一個 `TimelineBlock`（只有一條分隔線）
- PENDING（尚未送出）的 review 草稿過濾掉，不顯示
- 行內留言不做縮排排版——`markdown::render` 交給 `Paragraph::wrap` 折行，任何 gutter 前綴在折行後的第二列都會消失

Closes #94

## 本地驗證

- [x] `cargo fmt --all -- --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --verbose` 通過（576 個單元測試）